### PR TITLE
Allow for a LICENSES directory when writing wheel metadata

### DIFF
--- a/flit_core/flit_core/wheel.py
+++ b/flit_core/flit_core/wheel.py
@@ -195,7 +195,12 @@ class WheelBuilder:
 
         for base in ('COPYING', 'LICENSE'):
             for path in sorted(glob(osp.join(self.directory, base + '*'))):
-                self._add_file(path, '%s/%s' % (self.dist_info, osp.basename(path)))
+                if osp.isdir(path):
+                    for full_path in sorted(glob(osp.join(path, '*'))):
+                        rel_path = osp.relpath(full_path, self.directory)
+                        self._add_file(full_path, '%s/%s' % (self.dist_info, rel_path))
+                else:
+                    self._add_file(path, '%s/%s' % (self.dist_info, osp.basename(path)))
 
         with self._write_to_zip(self.dist_info + '/WHEEL') as f:
             _write_wheel_file(f, supports_py2=self.metadata.supports_py2)

--- a/tests/samples/module4_licenses_dir/LICENSES/MIT.txt
+++ b/tests/samples/module4_licenses_dir/LICENSES/MIT.txt
@@ -1,0 +1,19 @@
+MIT License Copyright (c) <year> <copyright holders>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is furnished
+to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice (including the next
+paragraph) shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS
+OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF
+OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/tests/samples/module4_licenses_dir/LICENSES/dummy.txt
+++ b/tests/samples/module4_licenses_dir/LICENSES/dummy.txt
@@ -1,0 +1,1 @@
+Dummy license - check that it gets packaged

--- a/tests/samples/module4_licenses_dir/flit.ini
+++ b/tests/samples/module4_licenses_dir/flit.ini
@@ -1,0 +1,5 @@
+[metadata]
+module=module4
+author=Sir Robin
+author-email=robin@camelot.uk
+home-page=http://github.com/sirrobin/module4

--- a/tests/samples/module4_licenses_dir/src/module4.py
+++ b/tests/samples/module4_licenses_dir/src/module4.py
@@ -1,0 +1,3 @@
+"""Example module"""
+
+__version__ = '0.1'

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -41,6 +41,20 @@ def test_wheel_src_module(copy_sample):
         assert_isdir(Path(unpacked, 'module3-0.1.dist-info'))
         assert_isfile(Path(unpacked, 'module3-0.1.dist-info', 'LICENSE'))
 
+def test_wheel_src_module_with_licenses_dir(copy_sample):
+    td = copy_sample('module4_licenses_dir')
+    wheel_main(td / 'flit.ini')
+
+    whl_file = td / 'dist/module4-0.1-py2.py3-none-any.whl'
+    assert_isfile(whl_file)
+    with unpack(whl_file) as unpacked:
+        assert_isfile(Path(unpacked, 'module4.py'))
+        assert_isdir(Path(unpacked, 'module4-0.1.dist-info'))
+        licenses = Path(unpacked, 'module4-0.1.dist-info', 'LICENSES')
+        assert_isdir(licenses)
+        assert_isfile(licenses / 'MIT.txt')
+        assert_isfile(licenses / 'dummy.txt')
+
 def test_wheel_src_package(copy_sample):
     td = copy_sample('package2')
     wheel_main(td / 'package2-pkg.ini')


### PR DESCRIPTION
The paths matched by `COPYING*` and `LICENSE*` when adding license files
to the dist-info directory are now allowed to be directories
containing the actual license files.