### PR TITLE
Fix ast version parser for multiple assignments

### DIFF
--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -132,15 +132,18 @@ def get_docstring_and_version_via_ast(target):
     for child in node.body:
         # Only use the version from the given module if it's a simple
         # string assignment to __version__
-        is_version_str = (
-                isinstance(child, ast.Assign)
-                and len(child.targets) == 1
-                and isinstance(child.targets[0], ast.Name)
-                and child.targets[0].id == "__version__"
-                and isinstance(child.value, ast.Str)
-        )
-        if is_version_str:
-            version = child.value.s
+        if isinstance(child, ast.Assign):
+            for target in child.targets:
+                is_version_str = (
+                    isinstance(target, ast.Name)
+                    and target.id == "__version__"
+                    and isinstance(child.value, ast.Str)
+                )
+                if is_version_str:
+                    version = child.value.s
+                    break
+            else:
+                continue
             break
     else:
         version = None

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -144,7 +144,6 @@ def get_docstring_and_version_via_ast(target):
         if is_version_str:
             version = child.value.s
             break
-            break
     else:
         version = None
     return ast.get_docstring(node), version

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -132,18 +132,18 @@ def get_docstring_and_version_via_ast(target):
     for child in node.body:
         # Only use the version from the given module if it's a simple
         # string assignment to __version__
-        if isinstance(child, ast.Assign):
-            for target in child.targets:
-                is_version_str = (
+        is_version_str = (
+                isinstance(child, ast.Assign)
+                and any(
                     isinstance(target, ast.Name)
                     and target.id == "__version__"
-                    and isinstance(child.value, ast.Str)
+                    for target in child.targets
                 )
-                if is_version_str:
-                    version = child.value.s
-                    break
-            else:
-                continue
+                and isinstance(child.value, ast.Str)
+        )
+        if is_version_str:
+            version = child.value.s
+            break
             break
     else:
         version = None

--- a/flit_core/flit_core/tests/samples/moduleunimportabledouble.py
+++ b/flit_core/flit_core/tests/samples/moduleunimportabledouble.py
@@ -1,0 +1,8 @@
+
+"""
+A sample unimportable module with double assignment
+"""
+
+raise ImportError()
+
+VERSION = __version__ = "0.1"

--- a/flit_core/flit_core/tests/test_common.py
+++ b/flit_core/flit_core/tests/test_common.py
@@ -70,6 +70,11 @@ class ModuleTests(TestCase):
                                 'version': '0.1'}
                          )
 
+        info = get_info_from_module(Module('moduleunimportabledouble', samples_dir))
+        self.assertEqual(info, {'summary': 'A sample unimportable module with double assignment',
+                                'version': '0.1'}
+                         )
+
         info = get_info_from_module(Module('module1', samples_dir / 'constructed_version'))
         self.assertEqual(info, {'summary': 'This module has a __version__ that requires runtime interpretation',
                                 'version': '1.2.3'}


### PR DESCRIPTION
Some projects seem to use multiple assignments which currently only seems to work if `__version__` is the first variable being assigned to.