### PR TITLE
Replace /takluyver/ by /pypa/ where relevant

### DIFF
--- a/doc/cmdline.rst
+++ b/doc/cmdline.rst
@@ -219,7 +219,7 @@ Environment variables
    If the metadata is invalid, uploading the package to PyPI may fail. This
    environment variable provides an escape hatch in case Flit incorrectly
    rejects your valid metadata. If you need to use it and you believe your
-   metadata is valid, please `open an issue <https://github.com/takluyver/flit/issues>`__.
+   metadata is valid, please `open an issue <https://github.com/pypa/flit/issues>`__.
 
 .. envvar:: FLIT_INSTALL_PYTHON
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -34,7 +34,7 @@ extensions = [
     'sphinx_rtd_theme',
 ]
 
-github_project_url = "https://github.com/takluyver/flit"
+github_project_url = "https://github.com/pypa/flit"
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/development.rst
+++ b/doc/development.rst
@@ -3,7 +3,7 @@ Developing Flit
 
 To get a development installation of Flit itself::
 
-    git clone https://github.com/takluyver/flit.git
+    git clone https://github.com/pypa/flit.git
     cd flit
     python3 -m pip install docutils requests toml
     python3 bootstrap_dev.py

--- a/doc/flit_ini.rst
+++ b/doc/flit_ini.rst
@@ -33,7 +33,7 @@ e.g. for flit itself
     module=flit
     author=Thomas Kluyver
     author-email=thomas@kluyver.me.uk
-    home-page=https://github.com/takluyver/flit
+    home-page=https://github.com/pypa/flit
 
 The remaining fields are optional:
 
@@ -86,7 +86,7 @@ Here's the full example from flit itself:
     [metadata]
     author=Thomas Kluyver
     author-email=thomas@kluyver.me.uk
-    home-page=https://github.com/takluyver/flit
+    home-page=https://github.com/pypa/flit
     requires=requests
     requires-python= >=3
     description-file=README.rst

--- a/doc/pyproject_toml.rst
+++ b/doc/pyproject_toml.rst
@@ -165,7 +165,7 @@ any names inside it. Here it is for flit:
 
   [project.urls]
   Documentation = "https://flit.readthedocs.io/en/latest/"
-  Source = "https://github.com/takluyver/flit"
+  Source = "https://github.com/pypa/flit"
 
 .. _pyproject_project_scripts:
 
@@ -332,7 +332,7 @@ Here was the metadata section from flit using the older style:
     module="flit"
     author="Thomas Kluyver"
     author-email="thomas@kluyver.me.uk"
-    home-page="https://github.com/takluyver/flit"
+    home-page="https://github.com/pypa/flit"
     requires=[
         "flit_core >=2.2.0",
         "requests",

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -30,7 +30,7 @@ def find_python_executable(python: Optional[str] = None) -> str:
         return python
     # get absolute filepath of {python}
     # shutil.which may give a different result to the raw subprocess call
-    # see https://github.com/takluyver/flit/pull/300 and https://bugs.python.org/issue38905
+    # see https://github.com/pypa/flit/pull/300 and https://bugs.python.org/issue38905
     resolved_python = shutil.which(python)
     if resolved_python is None:
         raise PythonNotFoundError("Unable to resolve Python executable {!r}".format(python))

--- a/flit_core/flit_core/build_thyself.py
+++ b/flit_core/flit_core/build_thyself.py
@@ -17,15 +17,16 @@ from .sdist import SdistBuilder
 from . import __version__
 
 metadata_dict = {
-    'name': 'flit_core',
-    'version': __version__,
-    'author': 'Thomas Kluyver & contributors',
-    'author_email': 'thomas@kluyver.me.uk',
-    'home_page': 'https://github.com/takluyver/flit',
-    'summary': ('Distribution-building parts of Flit. '
-                    'See flit package for more information'),
-    'requires_dist': [
-        'tomli',
+    "name": "flit_core",
+    "version": __version__,
+    "author": "Thomas Kluyver & contributors",
+    "author_email": "thomas@kluyver.me.uk",
+    "home_page": "https://github.com/pypa/flit",
+    "summary": (
+        "Distribution-building parts of Flit. " "See flit package for more information"
+    ),
+    "requires_dist": [
+        "tomli",
     ],
     'requires_python': '>=3.6',
     'classifiers': [

--- a/flit_core/flit_core/tests/samples/module2.py
+++ b/flit_core/flit_core/tests/samples/module2.py
@@ -4,7 +4,7 @@ Docstring formatted like this.
 
 a = {}
 # An assignment to a subscript (a['test']) broke introspection
-# https://github.com/takluyver/flit/issues/343
+# https://github.com/pypa/flit/issues/343
 a['test'] = 6
 
 __version__ = '7.0'

--- a/flit_core/flit_core/tests/test_wheel.py
+++ b/flit_core/flit_core/tests/test_wheel.py
@@ -8,7 +8,7 @@ from flit_core.wheel import make_wheel_in
 samples_dir = Path(__file__).parent / 'samples'
 
 def test_licenses_dir(tmp_path):
-    # Smoketest for https://github.com/takluyver/flit/issues/399
+    # Smoketest for https://github.com/pypa/flit/issues/399
     info = make_wheel_in(samples_dir / 'inclusion' / 'pyproject.toml', tmp_path)
     assert_isfile(info.file)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ doc = [
 
 [project.urls]
 Documentation = "https://flit.readthedocs.io/en/latest/"
-Source = "https://github.com/takluyver/flit"
+Source = "https://github.com/pypa/flit"
 
 [project.scripts]
 flit = "flit:main"

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -90,10 +90,11 @@ def test_validate_environment_marker():
 
 def test_validate_url():
     vurl = fv.validate_url
-    assert vurl('https://github.com/takluyver/flit') == []
+    assert vurl("https://github.com/pypa/flit") == []
 
-    assert len(vurl('github.com/takluyver/flit')) == 1
-    assert len(vurl('https://')) == 1
+    assert len(vurl("github.com/pypa/flit")) == 1
+    assert len(vurl("https://")) == 1
+
 
 def test_validate_project_urls():
     vpu = fv.validate_project_urls


### PR DESCRIPTION
While GitHub does redirect, it is good practice to fix links.

And the redirect will last only until Thomas decide to fork it again.

-- 

Note that my autoformater was a bit overzealous in replacing some simple to double quotes, I can redo those files if you wish to.