### PR TITLE
Add bootstrap install script for flit_core

### DIFF
--- a/flit_core/flit_core/build_thyself.py
+++ b/flit_core/flit_core/build_thyself.py
@@ -89,7 +89,7 @@ def build_sdist(sdist_directory, config_settings=None):
 
     sb = SdistBuilder(
         module, metadata, cwd, reqs_by_extra, entrypoints={},
-        extra_files=['pyproject.toml', 'build_dists.py']
+        extra_files=['pyproject.toml', 'build_dists.py', 'install_bootstrap.py']
     )
     path = sb.build(Path(sdist_directory))
     return path.name

--- a/flit_core/install_bootstrap.py
+++ b/flit_core/install_bootstrap.py
@@ -1,0 +1,37 @@
+"""Install flit_core without using any other tools.
+
+Normally, you would install flit_core with pip like any other Python package.
+This script is meant to help with 'bootstrapping' other packaging
+systems, where you may need flit_core to build other packaging tools.
+
+Pass a path to the site-packages directory or equivalent where the package
+should be placed. If omitted, this defaults to the site-packages directory
+of the Python running the script.
+"""
+import os
+import sys
+import sysconfig
+from tempfile import TemporaryDirectory
+from zipfile import ZipFile
+
+from flit_core import build_thyself
+
+os.chdir(os.path.dirname(os.path.abspath(__file__)))
+
+if len(sys.argv) == 2:
+    dest = sys.argv[1]
+    if not os.path.isdir(dest):
+        sys.exit("Destination path must already be a directory")
+elif len(sys.argv) == 1:
+    dest = sysconfig.get_path('purelib')
+else:
+    sys.exit("Specify 0 or 1 arguments (destination directory)")
+
+with TemporaryDirectory(prefix='flit_core-bootstrap-') as td:
+    print("Building wheel")
+    whl_fname = build_thyself.build_wheel(td)
+    whl_path = os.path.join(td, whl_fname)
+
+    print("Installing to", dest)
+    with ZipFile(whl_path) as zf:
+        zf.extractall(dest)


### PR DESCRIPTION
This builds a wheel and unzips it to `site-packages`, which is my suggestion for how downstream packagers bootstrap packaging tools. This isn't the only possible approach: https://github.com/FFY00/python-bootstrap shows how to have a set of basic tools all importable together for the bootstrapping phase.

This is deliberately lacking install features like removing a previous version, or atomic installation. It's meant to be run in a context where you know it's not already installed, and where a failure means the resulting state will be discarded anyway.

@jameshilliard, does this look like it would help you, following our discussion in #462?

If this approach is useful, it might be reasonable to add similar scripts for a few other pieces of low-level packaging infrastructure - in particular `tomli` and `installer` (cc @hukkin, @pradyunsg ). This is just a starting point for discussion.