### PR TITLE
Remove messages about setup.py default changing

### DIFF
--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -168,13 +168,6 @@ def main(argv=None):
 
     def gen_setup_py():
         if not (args.setup_py or args.no_setup_py):
-            log.info("Not generating setup.py in sdist (default changed)")
-            log.info(
-                "Recent versions of pip no longer need this generated file"
-            )
-            log.info(
-                "Use --[no-]setup-py to suppress this message or add setup.py"
-            )
             return False
         return args.setup_py
 


### PR DESCRIPTION
The default changed in 3.5 (2021-11-18). These messages were meant to be temporary, to alert people who might want a `setup.py` in their sdists that they should explicitly request it. I don't want to keep drawing attention to the feature, because eventually the `--setup-py` option will go away.