### PR TITLE
Import system tomli if vendor version not available

### DIFF
--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -7,7 +7,10 @@ import os.path as osp
 from pathlib import Path
 import re
 
-from .vendor import tomli
+try:
+    from .vendor import tomli
+except ModuleNotFoundError:
+    import tomli
 from .versionno import normalise_version
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
In Debian we try very hard to avoid vendoring, so I've patched flit 3.6.0 to use the system tomli.  Because of how our package archive is set up, we don't have the bootstrapping problem that is the reason you vendored it.  It would be nice if you would fall back to the system tomli so i didn't have to carry a patch for this.