### PR TITLE
Lowercase distribution name in wheel filename and .dist-info folder name

### DIFF
--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -407,7 +407,7 @@ def normalize_dist_name(name: str, version: str) -> str:
 
     See https://packaging.python.org/specifications/binary-distribution-format/#escaping-and-unicode
     """
-    normalized_name = re.sub(r'[-_.]+', '_', name, flags=re.UNICODE)
+    normalized_name = re.sub(r'[-_.]+', '_', name, flags=re.UNICODE).lower()
     assert check_version(version) == version
     assert '-' not in version, 'Normalized versions can’t have dashes'
     return '{}-{}'.format(normalized_name, version)

--- a/tests/samples/altdistname/pyproject.toml
+++ b/tests/samples/altdistname/pyproject.toml
@@ -7,5 +7,5 @@ module = "package1"
 author = "Sir Robin"
 author-email = "robin@camelot.uk"
 home-page = "http://github.com/sirrobin/package1"
-dist-name = "package-dist1"
+dist-name = "package-Dist1"
 


### PR DESCRIPTION
In line with this correction in the wheel spec: https://github.com/pypa/packaging.python.org/pull/1032

The [spec for `.dist-info` directories](https://packaging.python.org/en/latest/specifications/recording-installed-packages/) already requires this, by referring to [PEP 503](https://www.python.org/dev/peps/pep-0503/#normalized-names).