### PR TITLE
Use newer importlib APIs when loading module for docstring & __version__

### DIFF
--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -163,10 +163,13 @@ def get_docstring_and_version_via_import(target):
     _import_i += 1
 
     log.debug("Loading module %s", target.file)
-    from importlib.machinery import SourceFileLoader
-    sl = SourceFileLoader('flit_core.dummy.import%d' % _import_i, str(target.file))
+    from importlib.util import spec_from_file_location, module_from_spec
+    mod_name = 'flit_core.dummy.import%d' % _import_i
+    spec = spec_from_file_location(mod_name, target.file)
     with _module_load_ctx():
-        m = sl.load_module()
+        m = module_from_spec(spec)
+        spec.loader.exec_module(m)
+
     docstring = m.__dict__.get('__doc__', None)
     version = m.__dict__.get('__version__', None)
     return docstring, version


### PR DESCRIPTION
The API we were using before was deprecated and has started issuing warnings. I've based the new code on this example in the importlib docs: https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly

Closes #496.