### PR TITLE
External data directory

### DIFF
--- a/doc/pyproject_toml.rst
+++ b/doc/pyproject_toml.rst
@@ -428,6 +428,8 @@ Exclusions have priority over inclusions.
 External data section
 ---------------------
 
+.. versionadded:: 3.7
+
 Data files which your code will use should go inside the Python package folder.
 Flit will package these with no special configuration.
 
@@ -450,6 +452,11 @@ depends on how your package is installed and how those systems are configured.
 For instance, installing in a virtualenv usually doesn't affect anything outside
 that environment. Don't rely on these files being picked up unless you have
 close control of how the package will be installed.
+
+If you install a package with ``flit install --symlink``, a symlink is made
+for each file in the external data directory. Otherwise (including development
+installs with ``pip install -e``), these files are copied to their destination,
+so changes here won't take effect until you reinstall the package.
 
 .. note::
 

--- a/doc/pyproject_toml.rst
+++ b/doc/pyproject_toml.rst
@@ -417,4 +417,35 @@ These paths:
 
 Exclusions have priority over inclusions.
 
+External data section
+---------------------
+
+Data files which your code will use should go inside the Python package folder.
+Flit will package these with no special configuration.
+
+However, sometimes it's useful to package external files for system integration,
+such as man pages or files defining a Jupyter extension. To do this, arrange
+the files within a directory such as ``data``, next to your ``pyproject.toml``
+file, and add a section like this:
+
+.. code-block:: toml
+
+    [tool.flit.external-data]
+    directory = "data"
+
+Paths within this directory are typically installed to corresponding paths under
+a prefix (such as a virtualenv directory). E.g. you might save a man page for a
+script as ``(data)/share/man/man1/foo.1``.
+
+Whether these files are detected by the systems they're meant to integrate with
+depends on how your package is installed and how those systems are configured.
+For instance, installing in a virtualenv usually doesn't affect anything outside
+that environment. Don't rely on these files being picked up unless you have
+close control of how the package will be installed.
+
+.. note::
+
+   For users coming from setuptools: external data corresponds to setuptools'
+   ``data_files`` parameter, although setuptools offers more flexibility.
+
 .. _environment marker: https://www.python.org/dev/peps/pep-0508/#environment-markers

--- a/flit/install.py
+++ b/flit/install.py
@@ -196,6 +196,17 @@ class Installer(object):
 
                 self.installed_files.append(cmd_file)
 
+    def install_data_dir(self, target_data_dir):
+        for src_path in common.walk_data_dir(self.ini_info.data_directory):
+            rel_path = os.path.relpath(src_path, self.ini_info.data_directory)
+            dst_path = os.path.join(target_data_dir, rel_path)
+            os.makedirs(os.path.dirname(dst_path), exist_ok=True)
+            if self.symlink:
+                os.symlink(os.path.realpath(src_path), dst_path)
+            else:
+                shutil.copy2(src_path, dst_path)
+            self.installed_files.append(dst_path)
+
     def _record_installed_directory(self, path):
         for dirpath, dirnames, files in os.walk(path):
             for f in files:
@@ -331,6 +342,8 @@ class Installer(object):
 
         scripts = self.ini_info.entrypoints.get('console_scripts', {})
         self.install_scripts(scripts, dirs['scripts'])
+
+        self.install_data_dir(dirs['data'])
 
         self.write_dist_info(dirs['purelib'])
 

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -421,8 +421,8 @@ def dist_info_name(distribution, version):
 def walk_data_dir(data_directory):
     """Iterate over the files in the given data directory.
 
-    Yields absolute paths - caller may want to make them relative.
-    Excludes any __pycache__ subdirectories.
+    Yields paths prefixed with data_directory - caller may want to make them
+    relative to that. Excludes any __pycache__ subdirectories.
     """
     if data_directory is None:
         return

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -416,3 +416,20 @@ def normalize_dist_name(name: str, version: str) -> str:
 def dist_info_name(distribution, version):
     """Get the correct name of the .dist-info folder"""
     return normalize_dist_name(distribution, version) + '.dist-info'
+
+
+def walk_data_dir(data_directory):
+    """Iterate over the files in the given data directory.
+
+    Yields absolute paths - caller may want to make them relative.
+    Excludes any __pycache__ subdirectories.
+    """
+    if data_directory is None:
+        return
+
+    for dirpath, dirs, files in os.walk(data_directory):
+        for file in sorted(files):
+            full_path = os.path.join(dirpath, file)
+            yield full_path
+
+        dirs[:] = [d for d in sorted(dirs) if d != '__pycache__']

--- a/flit_core/flit_core/sdist.py
+++ b/flit_core/flit_core/sdist.py
@@ -72,13 +72,14 @@ class SdistBuilder:
     which is what should normally be published to PyPI.
     """
     def __init__(self, module, metadata, cfgdir, reqs_by_extra, entrypoints,
-                 extra_files, include_patterns=(), exclude_patterns=()):
+                 extra_files, data_directory, include_patterns=(), exclude_patterns=()):
         self.module = module
         self.metadata = metadata
         self.cfgdir = cfgdir
         self.reqs_by_extra = reqs_by_extra
         self.entrypoints = entrypoints
         self.extra_files = extra_files
+        self.data_directory = data_directory
         self.includes = FilePatterns(include_patterns, str(cfgdir))
         self.excludes = FilePatterns(exclude_patterns, str(cfgdir))
 
@@ -93,8 +94,8 @@ class SdistBuilder:
         extra_files = [ini_path.name] + ini_info.referenced_files
         return cls(
             module, metadata, srcdir, ini_info.reqs_by_extra,
-            ini_info.entrypoints, extra_files, ini_info.sdist_include_patterns,
-            ini_info.sdist_exclude_patterns,
+            ini_info.entrypoints, extra_files, ini_info.data_directory,
+            ini_info.sdist_include_patterns, ini_info.sdist_exclude_patterns,
         )
 
     def prep_entry_points(self):
@@ -115,6 +116,8 @@ class SdistBuilder:
         cfgdir_s = str(self.cfgdir)
         return [
             osp.relpath(p, cfgdir_s) for p in self.module.iter_files()
+        ] + [
+            osp.relpath(p, cfgdir_s) for p in common.walk_data_dir(self.data_directory)
         ] + self.extra_files
 
     def apply_includes_excludes(self, files):

--- a/flit_core/flit_core/tests/samples/with_data_dir/LICENSE
+++ b/flit_core/flit_core/tests/samples/with_data_dir/LICENSE
@@ -1,0 +1,1 @@
+This file should be added to wheels

--- a/flit_core/flit_core/tests/samples/with_data_dir/README.rst
+++ b/flit_core/flit_core/tests/samples/with_data_dir/README.rst
@@ -1,0 +1,1 @@
+This contains a nön-ascii character

--- a/flit_core/flit_core/tests/samples/with_data_dir/data/share/man/man1/foo.1
+++ b/flit_core/flit_core/tests/samples/with_data_dir/data/share/man/man1/foo.1
@@ -1,0 +1,1 @@
+Example data file

--- a/flit_core/flit_core/tests/samples/with_data_dir/module1.py
+++ b/flit_core/flit_core/tests/samples/with_data_dir/module1.py
@@ -1,0 +1,3 @@
+"""Example module"""
+
+__version__ = '0.1'

--- a/flit_core/flit_core/tests/samples/with_data_dir/pyproject.toml
+++ b/flit_core/flit_core/tests/samples/with_data_dir/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "module1"
+authors = [
+    {name = "Sir Röbin", email = "robin@camelot.uk"}
+]
+readme = "README.rst"
+license = {file = "LICENSE"}
+requires-python = ">=3.7"
+dependencies = [
+    "requests >= 2.18",
+    "docutils",
+]
+dynamic = [
+    "version",
+    "description",
+]
+
+[project.scripts]
+foo = "module1:main"
+
+[tool.flit.external-data]
+directory = "data"

--- a/flit_core/flit_core/tests/test_sdist.py
+++ b/flit_core/flit_core/tests/test_sdist.py
@@ -49,3 +49,12 @@ def test_include_exclude():
     assert osp.join('doc', 'test.rst') in files
     assert osp.join('doc', 'test.txt') not in files
     assert osp.join('doc', 'subdir', 'test.txt') in files
+
+
+def test_data_dir():
+    builder = sdist.SdistBuilder.from_ini_path(
+        samples_dir / 'with_data_dir' / 'pyproject.toml'
+    )
+    files = builder.apply_includes_excludes(builder.select_files())
+
+    assert osp.join('data', 'share', 'man', 'man1', 'foo.1') in files

--- a/flit_core/flit_core/tests/test_wheel.py
+++ b/flit_core/flit_core/tests/test_wheel.py
@@ -29,3 +29,10 @@ def test_zero_timestamp(tmp_path, monkeypatch):
     # Minimum value for zip timestamps is 1980-1-1
     with ZipFile(info.file, 'r') as zf:
         assert zf.getinfo('module1a.py').date_time == (1980, 1, 1, 0, 0, 0)
+
+
+def test_data_dir(tmp_path):
+    info = make_wheel_in(samples_dir / 'with_data_dir' / 'pyproject.toml', tmp_path)
+    assert_isfile(info.file)
+    with ZipFile(info.file, 'r') as zf:
+        assert 'module1-0.1.data/data/share/man/man1/foo.1' in zf.namelist()

--- a/flit_core/flit_core/wheel.py
+++ b/flit_core/flit_core/wheel.py
@@ -57,13 +57,16 @@ def zip_timestamp_from_env() -> Optional[tuple]:
 
 
 class WheelBuilder:
-    def __init__(self, directory, module, metadata, entrypoints, target_fp):
+    def __init__(
+            self, directory, module, metadata, entrypoints, target_fp, data_directory
+    ):
         """Build a wheel from a module/package
         """
         self.directory = directory
         self.module = module
         self.metadata = metadata
         self.entrypoints = entrypoints
+        self.data_directory = data_directory
 
         self.records = []
         self.source_time_stamp = zip_timestamp_from_env()
@@ -74,14 +77,15 @@ class WheelBuilder:
 
     @classmethod
     def from_ini_path(cls, ini_path, target_fp):
-        # Local import so bootstrapping doesn't try to load toml
         from .config import read_flit_config
         directory = ini_path.parent
         ini_info = read_flit_config(ini_path)
         entrypoints = ini_info.entrypoints
         module = common.Module(ini_info.module, directory)
         metadata = common.make_metadata(module, ini_info)
-        return cls(directory, module, metadata, entrypoints, target_fp)
+        return cls(
+            directory, module, metadata, entrypoints, target_fp, ini_info.data_directory
+        )
 
     @property
     def dist_info(self):
@@ -160,6 +164,14 @@ class WheelBuilder:
         with self._write_to_zip(self.module.name + ".pth") as f:
             f.write(str(self.module.source_dir.resolve()))
 
+    def add_data_directory(self):
+        dir_in_whl = '{}.data/data/'.format(
+            common.normalize_dist_name(self.metadata.name, self.metadata.version)
+        )
+        for full_path in common.walk_data_dir(self.data_directory):
+            rel_path = os.path.relpath(full_path, self.data_directory)
+            self._add_file(full_path, dir_in_whl + rel_path)
+
     def write_metadata(self):
         log.info('Writing metadata files')
 
@@ -193,6 +205,7 @@ class WheelBuilder:
                 self.add_pth()
             else:
                 self.copy_module()
+            self.add_data_directory()
             self.write_metadata()
             self.write_record()
         finally:

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -300,6 +300,8 @@ class InstallTests(TestCase):
         assert_isfile(self.tmpdir / 'data' / 'share' / 'man' / 'man1' / 'foo.1')
 
     def test_symlink_data_dir(self):
+        if os.name == 'nt':
+            raise SkipTest("symlink")
         Installer.from_ini_path(
             core_samples_dir / 'with_data_dir' / 'pyproject.toml', symlink=True
         ).install_directly()


### PR DESCRIPTION
Corresponding to setuptools' `data_files`, but less flexible: you just get one directory, which will be mapped to wherever the installer decides to put the 'data' component of the wheel (typically the prefix path).

Closes #358.