### PR TITLE
Output license.text to license field if supplied in metadata

### DIFF
--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -508,7 +508,7 @@ def read_pep621_metadata(proj, path) -> LoadedConfig:
                 )
             lc.referenced_files.append(license_tbl['file'])
         elif 'text' in license_tbl:
-            pass
+            md_dict['license'] = license_tbl['text']
         else:
             raise ConfigError(
                 "file or text field required in [project.license] table"


### PR DESCRIPTION
Until PEP 639 is finalized, many projects rely on the output of License
in PKG-INFO being an SPDX string, if it is using a standard license,
and third party tooling can process that.

Rather than silently ignoring license.text, use that to populate the
License field if it is provided, and leave it to downstream packages as
to whether they are supplying license.file or license.text