### PR TITLE
Normalize module name default value

### DIFF
--- a/doc/pyproject_toml.rst
+++ b/doc/pyproject_toml.rst
@@ -69,8 +69,9 @@ The allowed fields are:
 
 name
   The name your package will have on PyPI. This field is required. For Flit,
-  this also points to your package as an import name by default (see
-  :ref:`pyproject_module` if that needs to be different).
+  this name, with any hyphens replaced by underscores, is also the default value
+  of the import name (see :ref:`pyproject_module` if that needs to be
+  different).
 version
   Version number as a string. If you want Flit to get this from a
   ``__version__`` attribute, leave it out of the TOML config and include
@@ -232,6 +233,10 @@ you should specify the install (PyPI) name in the ``[project]`` table
 
     [tool.flit.module]
     name = "nsist"
+
+Flit looks for the source of the package by its import name. The source may be
+located either in the directory that holds the ``pyproject.toml`` file, or in a
+``src/`` subdirectory.
 
 .. _pyproject_old_metadata:
 

--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -426,7 +426,8 @@ def read_pep621_metadata(proj, path) -> LoadedConfig:
     if 'name' not in proj:
         raise ConfigError('name must be specified in [project] table')
     _check_type(proj, 'name', str)
-    lc.module = md_dict['name'] = proj['name']
+    md_dict['name'] = proj['name']
+    lc.module = md_dict['name'].replace('-', '_')
 
     unexpected_keys = proj.keys() - pep621_allowed_fields
     if unexpected_keys:

--- a/flit_core/flit_core/tests/samples/normalization/pyproject.toml
+++ b/flit_core/flit_core/tests/samples/normalization/pyproject.toml
@@ -1,0 +1,14 @@
+[build-system]
+requires = ["flit_core >=3.8,<4"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "my-python-module"
+version = "0.0.1"
+description = "Hyphenated package name, infered import name"
+authors = [
+    {name = "Sir Robin", email = "robin@camelot.uk"}
+]
+
+[project.urls]
+homepage = "http://github.com/me/python-module"

--- a/flit_core/flit_core/tests/test_config.py
+++ b/flit_core/flit_core/tests/test_config.py
@@ -20,6 +20,11 @@ def test_load_toml_ns():
     assert inf.module == 'ns1.pkg'
     assert inf.metadata['home_page'] == 'http://github.com/sirrobin/module1'
 
+def test_load_normalization():
+    inf = config.read_flit_config(samples_dir / 'normalization' / 'pyproject.toml')
+    assert inf.module == 'my_python_module'
+    assert inf.metadata['name'] == 'my-python-module'
+
 def test_load_pep621():
     inf = config.read_flit_config(samples_dir / 'pep621' / 'pyproject.toml')
     assert inf.module == 'module1a'


### PR DESCRIPTION
The package name is used as the default module name. Technically, the
module name must be normalized (no hyphens), so for convenience set the
default module name to the normalized package name, with hyphens replaced
by underscores.

---
Normalization is mentioned in [PEP426](https://peps.python.org/pep-0426/#name) and came up before in #149. ~The change proposed here was not tested (it is proposed to gauge interest and sentiment). Additionally, the documentation is not touched, but I feel normalization may be left implicit since~ a package name with hyphens isn't a valid import name to begin with.

_edit:_ To clarify, with this change the default module name for the `aiohttp-remotes` project becomes `aiohttp_remotes`.