### PR TITLE
Catch errors getting/setting password with keyring

### DIFF
--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -77,21 +77,19 @@ def test_get_repository_env():
 
 @contextmanager
 def _fake_keyring(pw):
-    real_keyring = sys.modules.get('keyring', None)
     class FakeKeyring:
         @staticmethod
         def get_password(service_name, username):
             return pw
 
-    sys.modules['keyring'] = FakeKeyring()
+    class FakeKeyringErrMod:
+        class KeyringError(Exception):
+            pass
 
-    try:
+    with patch.dict('sys.modules', {
+        'keyring': FakeKeyring(), 'keyring.errors': FakeKeyringErrMod(),
+    }):
         yield
-    finally:
-        if real_keyring is None:
-            del sys.modules['keyring']
-        else:
-            sys.modules['keyring'] = real_keyring
 
 pypirc2 = """
 [distutils]


### PR DESCRIPTION
Continue with a warning rather than error-ing out.

Fixes #538 (the part of it that Flit can control, at least)