### PR TITLE
Use tomllib instead of vendored tomli when available

### DIFF
--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -7,7 +7,11 @@ import os.path as osp
 from pathlib import Path
 import re
 
-from .vendor import tomli
+try:
+    import tomllib
+except ImportError:
+    from .vendor import tomli as tomllib
+
 from .versionno import normalise_version
 
 log = logging.getLogger(__name__)
@@ -66,7 +70,7 @@ pep621_allowed_fields = {
 def read_flit_config(path):
     """Read and check the `pyproject.toml` file with data about the package.
     """
-    d = tomli.loads(path.read_text('utf-8'))
+    d = tomllib.loads(path.read_text('utf-8'))
     return prep_toml_config(d, path)
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,6 @@ dependencies = [
     "flit_core >=3.7.1",
     "requests",
     "docutils",
-    "tomli",
     "tomli-w",
 ]
 requires-python = ">=3.6"
@@ -29,6 +28,7 @@ test = [
 	"responses",
 	"pytest>=2.7.3",
 	"pytest-cov",
+	"tomli",
 ]
 doc = [
 	"sphinx",


### PR DESCRIPTION
This allows unvendoring tomli assuming Python 3.11 or newer. FIxes https://github.com/pypa/flit/issues/544