### PR TITLE
Update link to external pip environment variables docs

### DIFF
--- a/doc/cmdline.rst
+++ b/doc/cmdline.rst
@@ -163,7 +163,7 @@ Flit guess.
 
    Flit calls pip to do the installation. You can set any of pip's options
    `using its environment variables
-   <https://pip.pypa.io/en/stable/user_guide/#environment-variables>`__.
+   <https://pip.pypa.io/en/stable/topics/configuration/#environment-variables>`__.
 
    When you use the :option:`--symlink` or :option:`--pth-file` options, pip
    is used to install dependencies. Otherwise, Flit builds a wheel and then


### PR DESCRIPTION
The link in the docs is outdated.