### PR TITLE
Enable `~=` syntax when checking Py2 compatibility

### DIFF
--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -398,7 +398,7 @@ class Metadata(object):
     def supports_py2(self):
         """Return True if Requires-Python indicates Python 2 support."""
         for part in (self.requires_python or "").split(","):
-            if re.search(r"^\s*(>\s*(=\s*)?)?[3-9]", part):
+            if re.search(r"^\s*([>~]\s*(=\s*)?)?[3-9]", part):
                 return False
         return True
 

--- a/flit_core/flit_core/tests/test_common.py
+++ b/flit_core/flit_core/tests/test_common.py
@@ -113,6 +113,8 @@ def test_normalize_file_permissions():
         ("<4, > 3.2", False),
         (">3.4", False),
         (">=2.7, !=3.0.*, !=3.1.*, !=3.2.*", True),
+        ("~3.3", False),
+        ("~2.7", True),
     ],
 )
 def test_supports_py2(requires_python, expected_result):


### PR DESCRIPTION
This should fix #476.

I do not remember full [PEP 440](https://peps.python.org/pep-0440/), so I am not sure whether there are other valid expressions to disallow Python 2 which would still be false-positive in flit.

Probably it would be better to use [specifiers from `packaging`](https://packaging.pypa.io/en/latest/specifiers.html) library so that flit does not need to implement own specifier parsing. Therefore this is just a quick fix for the issue at hand, which makes a small improvement but probably is not final.