### PR TITLE
Link to the stable release docs in project metadata

### DIFF
--- a/doc/pyproject_toml.rst
+++ b/doc/pyproject_toml.rst
@@ -165,7 +165,7 @@ any names inside it. Here it is for flit:
 .. code-block:: toml
 
   [project.urls]
-  Documentation = "https://flit.readthedocs.io/en/latest/"
+  Documentation = "https://flit.pypa.io"
   Source = "https://github.com/pypa/flit"
 
 .. _pyproject_project_scripts:
@@ -369,7 +369,7 @@ any names inside it. Here it is for flit:
 .. code-block:: toml
 
   [tool.flit.metadata.urls]
-  Documentation = "https://flit.readthedocs.io/en/latest/"
+  Documentation = "https://flit.pypa.io"
 
 .. versionadded:: 1.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,9 +37,9 @@ doc = [
 ]
 
 [project.urls]
-Documentation = "https://flit.readthedocs.io/en/latest/"
+Documentation = "https://flit.pypa.io"
 Source = "https://github.com/pypa/flit"
-Changelog = "https://flit.readthedocs.io/en/latest/history.html"
+Changelog = "https://flit.pypa.io/en/stable/history.html"
 
 [project.scripts]
 flit = "flit:main"


### PR DESCRIPTION
Since otherwise the documentation may not work for the current stable release, if new changes/features haven't yet been released.

In addition, the links now consistently use the `flit.pypa.io` custom domain, rather than the Read the Docs domain.

Closes #588.