### PR TITLE
Modify regex for checking py2 compatibility

### DIFF
--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -398,7 +398,7 @@ class Metadata(object):
     def supports_py2(self):
         """Return True if Requires-Python indicates Python 2 support."""
         for part in (self.requires_python or "").split(","):
-            if re.search(r"^\s*(>\s*(=\s*)?)?[3-9]", part):
+            if re.search(r"^\s*(>=?|~=|===?)?\s*?[3-9]", part):
                 return False
         return True
 

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -398,7 +398,7 @@ class Metadata(object):
     def supports_py2(self):
         """Return True if Requires-Python indicates Python 2 support."""
         for part in (self.requires_python or "").split(","):
-            if re.search(r"^\s*(>=?|~=|===?)?\s*?[3-9]", part):
+            if re.search(r"^\s*(>=?|~=|===?)?\s*[3-9]", part):
                 return False
         return True
 

--- a/flit_core/flit_core/tests/test_common.py
+++ b/flit_core/flit_core/tests/test_common.py
@@ -113,6 +113,9 @@ def test_normalize_file_permissions():
         ("<4, > 3.2", False),
         (">3.4", False),
         (">=2.7, !=3.0.*, !=3.1.*, !=3.2.*", True),
+        ("== 3.9", False),
+        ("~=2.7", True),
+        ("~=3.9", False),
     ],
 )
 def test_supports_py2(requires_python, expected_result):


### PR DESCRIPTION
Closes #476 and #591
Add support for compatible release version specifier '~=' and version matching clause '=='.

I was happy to see that someone picked up this issue in #586 , but it seems like the conversation stalled a bit, so here I am. It's something that was bothering me for a while now and it would be nice to see it fixed 😄 