### PR TITLE
docs: drop toml dependency from development.rst

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -5,7 +5,7 @@ To get a development installation of Flit itself::
 
     git clone https://github.com/pypa/flit.git
     cd flit
-    python3 -m pip install docutils requests toml
+    python3 -m pip install docutils requests
     python3 bootstrap_dev.py
 
 This links Flit into the current Python environment, so you can make changes


### PR DESCRIPTION
toml has been replaced by tomli and tomli-w. The latter is not needed to get a development installation and the former is either available as a standard library (as tomllib), or vendored from flit itself. Either way, no toml-related installation is necessary.

Inspired by a suggestion by Joe Drumgoole <Joe.Drumgoole@mongodb.com>

---
This is a follow-up on #480 :smiley:.