### PR TITLE
Remove vestigial tomli usage 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         platform: ["ubuntu-latest", "windows-latest"]
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11" ]
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         platform: ["ubuntu-latest", "windows-latest"]
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11" ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10", "3.11-dev" ]
     steps:
       - uses: actions/checkout@v3
 

--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -10,7 +10,12 @@ import re
 try:
     import tomllib
 except ImportError:
-    from .vendor import tomli as tomllib
+    try:
+        from .vendor import tomli as tomllib
+    # Some downstream distributors remove the vendored tomli.
+    # When that is removed, import tomli from the regular location.
+    except ImportError:
+        import tomli as tomllib
 
 from .versionno import normalise_version
 

--- a/tests/test_tomlify.py
+++ b/tests/test_tomlify.py
@@ -1,6 +1,9 @@
 import os
 from pathlib import Path
-import tomli
+try:
+    import tomllib
+except ImportError:
+    import tomli as tomllib
 from shutil import copy
 from testpath import assert_isfile
 
@@ -18,7 +21,7 @@ def test_tomlify(copy_sample, monkeypatch):
     assert_isfile(pyproject_toml)
 
     with pyproject_toml.open('rb') as f:
-        content = tomli.load(f)
+        content = tomllib.load(f)
 
     assert 'build-system' in content
     assert 'tool' in content

--- a/tox.ini
+++ b/tox.ini
@@ -16,7 +16,7 @@ deps =
     testpath
     responses
     docutils
-    tomli
+    tomli;python_version < "3.11"
     tomli-w
     pytest>=2.7.3
     pytest-cov

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{310,39,38,37,36},bootstrap
+envlist = py{311,310,39,38,37,36},bootstrap
 skip_missing_interpreters = true
 
 [gh-actions]
@@ -9,6 +9,7 @@ python =
     3.8: py38, bootstrap
     3.9: py39
     3.10: py310
+    3.11: py311
 
 [testenv]
 deps =


### PR DESCRIPTION
dba0f317c52d3c9fa29792a0beb0c0abf4476a23 removed some, but not all of the imports of the vendored tomli. This PR adds the same tomllib > tomli fallback to the tests and adjusts the tox.ini test deps accordingly.

Additionally, this adjusts flit-core to only use its vendored tomli when tomli isn't already installed. In Fedora, we bootstrap tomli differently, so we `rm -r` the vendored version. This change makes it so Fedora and other distributions don't also have to patch flit_core.config.

/cc @hroncok