### PR TITLE
tox: use allowlist_externals option instead of whitelist_externals

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,7 +34,7 @@ commands =
 skip_install = true
 # Make the install step a no-op, so nothing gets installed in the env
 install_command = true {packages}
-whitelist_externals = true
+allowlist_externals = true
 changedir = flit_core
 commands =
     python -c "from flit_core.buildapi import build_wheel;\


### PR DESCRIPTION
`whitelist_externals` was removed and deprecated in tox v 4.0.0.rc4 We should use `allowlist_externals` instead.

https://tox.wiki/en/latest/changelog.html#deprecations-and-removals-4-0-0rc4