### PR TITLE
Add --use-vcs and --no-use-vcs flags for build commands

### DIFF
--- a/doc/pyproject_toml.rst
+++ b/doc/pyproject_toml.rst
@@ -400,10 +400,13 @@ Sdist section
 
 .. versionadded:: 2.0
 
-When you use :ref:`build_cmd` or :ref:`publish_cmd`, Flit builds an sdist
-(source distribution) tarball containing the files that are checked into version
-control (git or mercurial). If you want more control, or it doesn't recognise
-your version control system, you can give lists of paths or glob patterns as
+With no configuration, Flit can make an sdist with everything it needs
+to build and install your module: the package contents (including non-Python
+data files, but not ``.pyc`` bytecode files), your ``pyproject.toml`` file,
+the readme & license files given in the metadata, and the :ref:`external data
+folder <pyproject_toml_external_data>` if you specified that.
+
+If you want more control, you can give lists of paths or glob patterns as
 ``include`` and ``exclude`` in this section. For example:
 
 .. code-block:: toml
@@ -429,13 +432,22 @@ These paths:
 Exclusions have priority over inclusions. Bytecode is excluded by default and cannot
 be included.
 
-.. note::
+Including files committed in git/hg
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-   If you are not using :ref:`build_cmd` but  ``flit_core`` via another build
-   frontend, Flit doesn't doesn't check the VCS for files to include but instead
-   builds a 'minimal' sdist (which includes the files necessary to build a wheel).
-   You'll have to adapt your inclusion/exclusion rules to achieve the same result
-   as you'd get with :ref:`build_cmd`.
+If you use :ref:`build_cmd` or :ref:`publish_cmd`, you can also make sdists with
+the files which are committed in version control (git or hg). This is a shortcut
+to e.g. include documentation source files, but not built HTML or PDF
+documentation. The include and exclude patterns are then applied on top of this
+list.
+
+For now, including files from version control is the default for :ref:`build_cmd`
+and :ref:`publish_cmd`, and can be disabled with ``--no-use-vcs``. The default
+will switch in a future version.
+
+Using ``flit_core`` as a backend to other tools such as `build
+<https://pypa-build.readthedocs.io/en/latest/>`_ never gets the list of files
+for the sdist from version control.
 
 .. _pyproject_toml_external_data:
 

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -92,7 +92,7 @@ def add_shared_build_options(parser: argparse.ArgumentParser):
     vcs_grp = parser.add_mutually_exclusive_group()
 
     vcs_grp.add_argument('--use-vcs', action='store_true',
-        help=("Get the list of files to include in the sdist from git or hg. "
+        help=("Choose which files to include in the sdist using git or hg. "
               "This is a convenient way to include all checked-in files, like "
               "tests and doc source files, in your sdist, but requires that git "
               "or hg is available on the command line. This is currently the "

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -67,7 +67,47 @@ def add_shared_install_options(parser: argparse.ArgumentParser):
         help="Install the dependencies of these (comma separated) extras additionally to the ones implied by --deps. "
              "--extras=all can be useful in combination with --deps=production, --deps=none precludes using --extras"
     )
-    
+
+
+def add_shared_build_options(parser: argparse.ArgumentParser):
+    parser.add_argument('--format', action='append',
+        help="Select a format to publish. Options: 'wheel', 'sdist'"
+    )
+
+    setup_py_grp = parser.add_mutually_exclusive_group()
+
+    setup_py_grp.add_argument('--setup-py', action='store_true',
+        help=("Generate a setup.py file in the sdist. "
+              "The sdist will work with older tools that predate PEP 517. "
+            )
+    )
+
+    setup_py_grp.add_argument('--no-setup-py', action='store_true',
+        help=("Don't generate a setup.py file in the sdist. This is the default. "
+              "The sdist will only work with tools that support PEP 517, "
+              "but the wheel will still be usable by any compatible tool."
+             )
+    )
+
+    vcs_grp = parser.add_mutually_exclusive_group()
+
+    vcs_grp.add_argument('--use-vcs', action='store_true',
+        help=("Get the list of files to include in the sdist from git or hg. "
+              "This is a convenient way to include all checked-in files, like "
+              "tests and doc source files, in your sdist, but requires that git "
+              "or hg is available on the command line. This is currently the "
+              "default, but it will change in a future version. "
+             )
+    )
+
+    vcs_grp.add_argument('--no-use-vcs', action='store_true',
+        help=("Select the files to include in the sdist without using git or hg. "
+              "This should include all essential files to install and use your "
+              "package; see the documentation for precisely what is included. "
+              "This will become the default in a future version."
+             )
+    )
+
 
 def main(argv=None):
     ap = argparse.ArgumentParser()
@@ -85,45 +125,14 @@ def main(argv=None):
         help="Build wheel and sdist",
     )
 
-    parser_build.add_argument('--format', action='append',
-        help="Select a format to build. Options: 'wheel', 'sdist'"
-    )
-
-    parser_build.add_argument('--setup-py', action='store_true',
-        help=("Generate a setup.py file in the sdist. "
-              "The sdist will work with older tools that predate PEP 517. "
-              )
-    )
-
-    parser_build.add_argument('--no-setup-py', action='store_true',
-        help=("Don't generate a setup.py file in the sdist. This is the default. "
-              "The sdist will only work with tools that support PEP 517, "
-              "but the wheel will still be usable by any compatible tool."
-             )
-    )
+    add_shared_build_options(parser_build)
 
     # flit publish --------------------------------------------
     parser_publish = subparsers.add_parser('publish',
         help="Upload wheel and sdist",
     )
 
-    parser_publish.add_argument('--format', action='append',
-        help="Select a format to publish. Options: 'wheel', 'sdist'"
-    )
-
-    parser_publish.add_argument('--setup-py', action='store_true',
-        help=("Generate a setup.py file in the sdist. "
-              "The sdist will work with older tools that predate PEP 517. "
-              "This is the default for now, but will change in a future version."
-              )
-    )
-
-    parser_publish.add_argument('--no-setup-py', action='store_true',
-        help=("Don't generate a setup.py file in the sdist. "
-              "The sdist will only work with tools that support PEP 517, "
-              "but the wheel will still be usable by any compatible tool."
-             )
-    )
+    add_shared_build_options(parser_publish)
 
     parser_publish.add_argument('--pypirc',
         help="The .pypirc config file to be used. DEFAULT = \"~/.pypirc\""
@@ -173,11 +182,14 @@ def main(argv=None):
             return False
         return args.setup_py
 
+    def sdist_use_vcs():
+        return not args.no_use_vcs
+
     if args.subcmd == 'build':
         from .build import main
         try:
             main(args.ini_file, formats=set(args.format or []),
-                 gen_setup_py=gen_setup_py())
+                 gen_setup_py=gen_setup_py(), use_vcs=sdist_use_vcs())
         except(common.NoDocstringError, common.VCSError, common.NoVersionError) as e:
             sys.exit(e.args[0])
     elif args.subcmd == 'publish':
@@ -186,7 +198,7 @@ def main(argv=None):
         repository = args.repository or args.deprecated_repository
         from .upload import main
         main(args.ini_file, repository, args.pypirc, formats=set(args.format or []),
-                gen_setup_py=gen_setup_py())
+                gen_setup_py=gen_setup_py(), use_vcs=sdist_use_vcs())
 
     elif args.subcmd == 'install':
         from .install import Installer

--- a/flit/build.py
+++ b/flit/build.py
@@ -26,7 +26,7 @@ def unpacked_tarball(path):
         assert len(files) == 1, files
         yield os.path.join(tmpdir, files[0])
 
-def main(ini_file: Path, formats=None, gen_setup_py=True):
+def main(ini_file: Path, formats=None, gen_setup_py=True, use_vcs=True):
     """Build wheel and sdist"""
     if not formats:
         formats = ALL_FORMATS
@@ -42,7 +42,7 @@ def main(ini_file: Path, formats=None, gen_setup_py=True):
         read_flit_config(ini_file)
 
         if 'sdist' in formats:
-            sb = SdistBuilder.from_ini_path(ini_file)
+            sb = SdistBuilder.from_ini_path(ini_file, use_vcs=use_vcs)
             sdist_file = sb.build(dist_dir, gen_setup_py=gen_setup_py)
             sdist_info = SimpleNamespace(builder=sb, file=sdist_file)
             # When we're building both, build the wheel from the unpacked sdist.

--- a/flit/sdist.py
+++ b/flit/sdist.py
@@ -156,7 +156,18 @@ class SdistBuilder(SdistBuilderCore):
     - Add a generated setup.py for compatibility with tools which don't yet know
       about PEP 517.
     """
+    use_vcs = True
+
+    @classmethod
+    def from_ini_path(cls, ini_path: Path, use_vcs=True):
+        inst = super().from_ini_path(ini_path)
+        inst.use_vcs = use_vcs
+        return inst
+
     def select_files(self):
+        if not self.use_vcs:
+            return super().select_files()
+
         vcs_mod = identify_vcs(self.cfgdir)
         if vcs_mod is not None:
             untracked_deleted = vcs_mod.list_untracked_deleted_files(self.cfgdir)

--- a/flit/upload.py
+++ b/flit/upload.py
@@ -260,7 +260,8 @@ def do_upload(file:Path, metadata:Metadata, pypirc_path="~/.pypirc", repo_name=N
         log.info("Package is at %s/%s", repo['url'], metadata.name)
 
 
-def main(ini_path, repo_name, pypirc_path=None, formats=None, gen_setup_py=True):
+def main(ini_path, repo_name, pypirc_path=None, formats=None, gen_setup_py=True,
+         use_vcs=True):
     """Build and upload wheel and sdist."""
     if pypirc_path is None:
         pypirc_path = PYPIRC_DEFAULT
@@ -268,7 +269,9 @@ def main(ini_path, repo_name, pypirc_path=None, formats=None, gen_setup_py=True)
         raise FileNotFoundError("The specified pypirc config file does not exist.")
 
     from . import build
-    built = build.main(ini_path, formats=formats, gen_setup_py=gen_setup_py)
+    built = build.main(
+        ini_path, formats=formats, gen_setup_py=gen_setup_py, use_vcs=use_vcs
+    )
 
     if built.wheel is not None:
         do_upload(built.wheel.file, built.wheel.builder.metadata, pypirc_path, repo_name)


### PR DESCRIPTION
From the discussion on #522, this adds an option to not use the VCS to get the list of files to include in the sdist. So `flit build --no-use-vcs` is equivalent to `python -m build` with flit_core as a backend. The idea is that in a future version (4.0?), this will become the default, and you will need to use `--use-vcs` to explicitly choose the sdist-files-from-vcs behaviour.

I've also tried to improve the documentation about what gets included in the sdist by default.