### PR TITLE
flit_core: Normalize sdist names according to PEP 625

### DIFF
--- a/flit_core/flit_core/sdist.py
+++ b/flit_core/flit_core/sdist.py
@@ -157,13 +157,11 @@ class SdistBuilder:
 
     @property
     def dir_name(self):
-        return '{}-{}'.format(self.metadata.name, self.metadata.version)
+        return common.normalize_dist_name(self.metadata.name, self.metadata.version)
 
     def build(self, target_dir, gen_setup_py=True):
         os.makedirs(str(target_dir), exist_ok=True)
-        target = target_dir / '{}-{}.tar.gz'.format(
-                self.metadata.name, self.metadata.version
-        )
+        target = target_dir / '{}.tar.gz'.format(self.dir_name)
         source_date_epoch = os.environ.get('SOURCE_DATE_EPOCH', '')
         mtime = int(source_date_epoch) if source_date_epoch else None
         gz = GzipFile(str(target), mode='wb', mtime=mtime)

--- a/flit_core/flit_core/tests/test_sdist.py
+++ b/flit_core/flit_core/tests/test_sdist.py
@@ -59,3 +59,12 @@ def test_data_dir():
     files = builder.apply_includes_excludes(builder.select_files())
 
     assert osp.join('data', 'share', 'man', 'man1', 'foo.1') in files
+
+
+def test_pep625(tmp_path):
+    builder = sdist.SdistBuilder.from_ini_path(
+        samples_dir / 'normalization' / 'pyproject.toml'
+    )
+    path = builder.build(tmp_path)
+    assert path == tmp_path / 'my_python_module-0.0.1.tar.gz'
+    assert_isfile(path)


### PR DESCRIPTION
Normalize generated source distribution names using the same rules as wheels, as required by PEP 625 [1].  This aligns flit_core with other modern PEP 517 backends such as hatchling.

[1] https://peps.python.org/pep-0625/

Fixes #626