### PR TITLE
Read version from version files via ast

### DIFF
--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -73,6 +73,10 @@ class Module(object):
 
     @property
     def version_files(self):
+    """Files which will be parsed to find a version number
+    
+    Files later in this list take precedence over earlier ones.
+    """
         if self.is_package:
             paths = [self.path / '__init__.py']
             for filename in ('version.py', '_version.py', '__version__.py'):

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -73,10 +73,10 @@ class Module(object):
 
     @property
     def version_files(self):
-    """Files which will be parsed to find a version number
-    
-    Files later in this list take precedence over earlier ones.
-    """
+        """Files which will be parsed to find a version number
+
+        Files later in this list take precedence over earlier ones.
+        """
         if self.is_package:
             paths = [self.path / '__init__.py']
             for filename in ('version.py', '_version.py', '__version__.py'):

--- a/flit_core/flit_core/tests/samples/imported_version/package1/__init__.py
+++ b/flit_core/flit_core/tests/samples/imported_version/package1/__init__.py
@@ -1,3 +1,5 @@
 """This module has a __version__ that requires a relative import"""
 
 from ._version import __version__
+
+import a_package_that_doesnt_exist

--- a/flit_core/flit_core/tests/samples/imported_version/package1/_version.py
+++ b/flit_core/flit_core/tests/samples/imported_version/package1/_version.py
@@ -1,1 +1,3 @@
+"""Imposter docstring that shouldn't be used"""
+
 __version__ = '0.5.8'


### PR DESCRIPTION
In cases where packages import `__version__` from version modules (like
those generated by setuptools_scm or attribution), this allows flit-core
to use the existing ast-based logic to read the version directly from
those files when possible. It checks a few well-known version filenames,
including the package-level `__init__.py` as usual, with `__init__.py`
taking precedence over external version files if an assigned
`__version__` value exists in multiple places.

This makes flit more resilient to reading version from these packages,
even if their `__init__.py` has transitive imports that aren't available
in the environment at build time (eg, conda-forge builds). It also
reduces the number of times when flit has to fall back to actually
importing the `__init__.py` file rather than reading with ast.
