### PR TITLE
Enable --only-deps with FLIT_ALLOW_INVALID

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/devcontainers/python:3
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install pytest pytest-cov \
+    && python -m pip install 'flit>=3.8.0'
+
+ENV FLIT_ROOT_INSTALL=1
+
+COPY pyproject.toml README.rst ./
+RUN mkdir -p flit \
+    && python -m flit install --only-deps --deps develop \
+    && rm -r pyproject.toml README.rst flit

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,43 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.222.0/containers/python-3-miniconda
+{
+	"name": "Python Environment",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"context": ".."
+	},
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"editorconfig.editorconfig",
+				"github.vscode-pull-request-github",
+				"ms-azuretools.vscode-docker",
+				"ms-python.python",
+				"ms-python.vscode-pylance",
+				"ms-python.pylint",
+				"ms-python.flake8",
+				"ms-python.black-formatter",
+				"ms-vsliveshare.vsliveshare",
+				"ryanluker.vscode-coverage-gutters",
+				"bungcip.better-toml",
+				"GitHub.copilot"
+			],
+			"settings": {
+				"python.defaultInterpreterPath": "/usr/local/bin/python",
+				"python.formatting.provider": "black",
+				"[python]": {
+					"editor.defaultFormatter": "ms-python.black-formatter"
+				},
+				"black-formatter.path": [
+					"/usr/local/py-utils/bin/black"
+				],
+				"pylint.path": [
+					"/usr/local/py-utils/bin/pylint"
+				],
+				"flake8.path": [
+					"/usr/local/py-utils/bin/flake8"
+				]
+			}
+		}
+	}
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,35 @@
+{
+    "editor.formatOnSave": true,
+    "editor.formatOnPaste": true,
+    "files.trimTrailingWhitespace": true,
+    "files.autoSave": "onFocusChange",
+    "git.autofetch": true,
+    "[jsonc]": {
+        "editor.defaultFormatter": "vscode.json-language-features"
+    },
+    "[python]": {
+        "editor.defaultFormatter": "ms-python.black-formatter"
+    },
+    "python.defaultInterpreterPath": "/usr/local/bin/python",
+    "python.formatting.provider": "black",
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestEnabled": true,
+    "pylint.args": [
+        "--rcfile=pyproject.toml"
+    ],
+    "pylint.path": [
+        "/usr/local/py-utils/bin/pylint"
+    ],
+    "black-formatter.args": [
+        "--config=pyproject.toml"
+    ],
+    "black-formatter.path": [
+        "/usr/local/py-utils/bin/black"
+    ],
+    "flake8.args": [
+        "--config=.flake8"
+    ],
+    "flake8.path": [
+        "/usr/local/py-utils/bin/flake8"
+    ]
+}

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -12,12 +12,13 @@ from flit_core import common
 from .config import ConfigError
 from .log import enable_colourful_output
 
-__version__ = '3.8.0'
+__version__ = "3.8.0"
 
 log = logging.getLogger(__name__)
 
 
-class PythonNotFoundError(FileNotFoundError): pass
+class PythonNotFoundError(FileNotFoundError):
+    pass
 
 
 def find_python_executable(python: Optional[str] = None) -> str:
@@ -33,7 +34,9 @@ def find_python_executable(python: Optional[str] = None) -> str:
     # see https://github.com/pypa/flit/pull/300 and https://bugs.python.org/issue38905
     resolved_python = shutil.which(python)
     if resolved_python is None:
-        raise PythonNotFoundError("Unable to resolve Python executable {!r}".format(python))
+        raise PythonNotFoundError(
+            "Unable to resolve Python executable {!r}".format(python)
+        )
     try:
         return subprocess.check_output(
             [resolved_python, "-c", "import sys; print(sys.executable)"],
@@ -48,125 +51,167 @@ def find_python_executable(python: Optional[str] = None) -> str:
 
 
 def add_shared_install_options(parser: argparse.ArgumentParser):
-    parser.add_argument('--user', action='store_true', default=None,
-        help="Do a user-local install (default if site.ENABLE_USER_SITE is True)"
+    parser.add_argument(
+        "--user",
+        action="store_true",
+        default=None,
+        help="Do a user-local install (default if site.ENABLE_USER_SITE is True)",
     )
-    parser.add_argument('--env', action='store_false', dest='user',
-        help="Install into sys.prefix (default if site.ENABLE_USER_SITE is False, i.e. in virtualenvs)"
+    parser.add_argument(
+        "--env",
+        action="store_false",
+        dest="user",
+        help="Install into sys.prefix (default if site.ENABLE_USER_SITE is False, i.e. in virtualenvs)",
     )
-    parser.add_argument('--python',
-        help="Target Python executable, if different from the one running flit"
+    parser.add_argument(
+        "--python",
+        help="Target Python executable, if different from the one running flit",
     )
-    parser.add_argument('--deps', choices=['all', 'production', 'develop', 'none'], default='all',
-        help="Which set of dependencies to install. If --deps=develop, the extras dev, doc, and test are installed"
+    parser.add_argument(
+        "--deps",
+        choices=["all", "production", "develop", "none"],
+        default="all",
+        help="Which set of dependencies to install. If --deps=develop, the extras dev, doc, and test are installed",
     )
-    parser.add_argument('--only-deps', action='store_true',
-        help="Install only dependencies of this package, and not the package itself"
+    parser.add_argument(
+        "--only-deps",
+        action="store_true",
+        help="Install only dependencies of this package, and not the package itself",
     )
-    parser.add_argument('--extras', default=(), type=lambda l: l.split(',') if l else (),
+    parser.add_argument(
+        "--extras",
+        default=(),
+        type=lambda l: l.split(",") if l else (),
         help="Install the dependencies of these (comma separated) extras additionally to the ones implied by --deps. "
-             "--extras=all can be useful in combination with --deps=production, --deps=none precludes using --extras"
+        "--extras=all can be useful in combination with --deps=production, --deps=none precludes using --extras",
     )
 
 
 def add_shared_build_options(parser: argparse.ArgumentParser):
-    parser.add_argument('--format', action='append',
-        help="Select a format to publish. Options: 'wheel', 'sdist'"
+    parser.add_argument(
+        "--format",
+        action="append",
+        help="Select a format to publish. Options: 'wheel', 'sdist'",
     )
 
     setup_py_grp = parser.add_mutually_exclusive_group()
 
-    setup_py_grp.add_argument('--setup-py', action='store_true',
-        help=("Generate a setup.py file in the sdist. "
-              "The sdist will work with older tools that predate PEP 517. "
-            )
+    setup_py_grp.add_argument(
+        "--setup-py",
+        action="store_true",
+        help=(
+            "Generate a setup.py file in the sdist. "
+            "The sdist will work with older tools that predate PEP 517. "
+        ),
     )
 
-    setup_py_grp.add_argument('--no-setup-py', action='store_true',
-        help=("Don't generate a setup.py file in the sdist. This is the default. "
-              "The sdist will only work with tools that support PEP 517, "
-              "but the wheel will still be usable by any compatible tool."
-             )
+    setup_py_grp.add_argument(
+        "--no-setup-py",
+        action="store_true",
+        help=(
+            "Don't generate a setup.py file in the sdist. This is the default. "
+            "The sdist will only work with tools that support PEP 517, "
+            "but the wheel will still be usable by any compatible tool."
+        ),
     )
 
     vcs_grp = parser.add_mutually_exclusive_group()
 
-    vcs_grp.add_argument('--use-vcs', action='store_true',
-        help=("Choose which files to include in the sdist using git or hg. "
-              "This is a convenient way to include all checked-in files, like "
-              "tests and doc source files, in your sdist, but requires that git "
-              "or hg is available on the command line. This is currently the "
-              "default, but it will change in a future version. "
-             )
+    vcs_grp.add_argument(
+        "--use-vcs",
+        action="store_true",
+        help=(
+            "Choose which files to include in the sdist using git or hg. "
+            "This is a convenient way to include all checked-in files, like "
+            "tests and doc source files, in your sdist, but requires that git "
+            "or hg is available on the command line. This is currently the "
+            "default, but it will change in a future version. "
+        ),
     )
 
-    vcs_grp.add_argument('--no-use-vcs', action='store_true',
-        help=("Select the files to include in the sdist without using git or hg. "
-              "This should include all essential files to install and use your "
-              "package; see the documentation for precisely what is included. "
-              "This will become the default in a future version."
-             )
+    vcs_grp.add_argument(
+        "--no-use-vcs",
+        action="store_true",
+        help=(
+            "Select the files to include in the sdist without using git or hg. "
+            "This should include all essential files to install and use your "
+            "package; see the documentation for precisely what is included. "
+            "This will become the default in a future version."
+        ),
     )
 
 
 def main(argv=None):
     ap = argparse.ArgumentParser()
-    ap.add_argument('-f', '--ini-file', type=pathlib.Path, default='pyproject.toml')
-    ap.add_argument('-V', '--version', action='version', version='Flit '+__version__)
+    ap.add_argument("-f", "--ini-file", type=pathlib.Path, default="pyproject.toml")
+    ap.add_argument("-V", "--version", action="version", version="Flit " + __version__)
     # --repository now belongs on 'flit publish' - it's still here for
     # compatibility with scripts passing it before the subcommand.
-    ap.add_argument('--repository', dest='deprecated_repository', help=argparse.SUPPRESS)
-    ap.add_argument('--debug', action='store_true', help=argparse.SUPPRESS)
-    ap.add_argument('--logo', action='store_true', help=argparse.SUPPRESS)
-    subparsers = ap.add_subparsers(title='subcommands', dest='subcmd')
+    ap.add_argument(
+        "--repository", dest="deprecated_repository", help=argparse.SUPPRESS
+    )
+    ap.add_argument("--debug", action="store_true", help=argparse.SUPPRESS)
+    ap.add_argument("--logo", action="store_true", help=argparse.SUPPRESS)
+    subparsers = ap.add_subparsers(title="subcommands", dest="subcmd")
 
     # flit build --------------------------------------------
-    parser_build = subparsers.add_parser('build',
+    parser_build = subparsers.add_parser(
+        "build",
         help="Build wheel and sdist",
     )
 
     add_shared_build_options(parser_build)
 
     # flit publish --------------------------------------------
-    parser_publish = subparsers.add_parser('publish',
+    parser_publish = subparsers.add_parser(
+        "publish",
         help="Upload wheel and sdist",
     )
 
     add_shared_build_options(parser_publish)
 
-    parser_publish.add_argument('--pypirc',
-        help="The .pypirc config file to be used. DEFAULT = \"~/.pypirc\""
+    parser_publish.add_argument(
+        "--pypirc", help='The .pypirc config file to be used. DEFAULT = "~/.pypirc"'
     )
 
-    parser_publish.add_argument('--repository',
-        help="Name of the repository to upload to (must be in the specified .pypirc file)"
+    parser_publish.add_argument(
+        "--repository",
+        help="Name of the repository to upload to (must be in the specified .pypirc file)",
     )
 
     # flit install --------------------------------------------
-    parser_install = subparsers.add_parser('install',
+    parser_install = subparsers.add_parser(
+        "install",
         help="Install the package",
     )
-    parser_install.add_argument('-s', '--symlink', action='store_true',
-        help="Symlink the module/package into site packages instead of copying it"
+    parser_install.add_argument(
+        "-s",
+        "--symlink",
+        action="store_true",
+        help="Symlink the module/package into site packages instead of copying it",
     )
-    parser_install.add_argument('--pth-file', action='store_true',
-        help="Add .pth file for the module/package to site packages instead of copying it"
+    parser_install.add_argument(
+        "--pth-file",
+        action="store_true",
+        help="Add .pth file for the module/package to site packages instead of copying it",
     )
     add_shared_install_options(parser_install)
 
     # flit init --------------------------------------------
-    parser_init = subparsers.add_parser('init',
-        help="Prepare pyproject.toml for a new package"
+    parser_init = subparsers.add_parser(
+        "init", help="Prepare pyproject.toml for a new package"
     )
 
     args = ap.parse_args(argv)
 
-    if args.ini_file.suffix == '.ini':
-        sys.exit("flit.ini format is no longer supported. You can use "
-                 "'python3 -m flit.tomlify' to convert it to pyproject.toml")
+    if args.ini_file.suffix == ".ini":
+        sys.exit(
+            "flit.ini format is no longer supported. You can use "
+            "'python3 -m flit.tomlify' to convert it to pyproject.toml"
+        )
 
-    if args.subcmd not in {'init'} and not args.ini_file.is_file():
-        sys.exit('Config file {} does not exist'.format(args.ini_file))
+    if args.subcmd not in {"init"} and not args.ini_file.is_file():
+        sys.exit("Config file {} does not exist".format(args.ini_file))
 
     enable_colourful_output(logging.DEBUG if args.debug else logging.INFO)
 
@@ -174,6 +219,7 @@ def main(argv=None):
 
     if args.logo:
         from .logo import clogo
+
         print(clogo.format(version=__version__))
         sys.exit(0)
 
@@ -185,23 +231,38 @@ def main(argv=None):
     def sdist_use_vcs():
         return not args.no_use_vcs
 
-    if args.subcmd == 'build':
+    if args.subcmd == "build":
         from .build import main
+
         try:
-            main(args.ini_file, formats=set(args.format or []),
-                 gen_setup_py=gen_setup_py(), use_vcs=sdist_use_vcs())
-        except(common.NoDocstringError, common.VCSError, common.NoVersionError) as e:
+            main(
+                args.ini_file,
+                formats=set(args.format or []),
+                gen_setup_py=gen_setup_py(),
+                use_vcs=sdist_use_vcs(),
+            )
+        except (common.NoDocstringError, common.VCSError, common.NoVersionError) as e:
             sys.exit(e.args[0])
-    elif args.subcmd == 'publish':
+    elif args.subcmd == "publish":
         if args.deprecated_repository:
-            log.warning("Passing --repository before the 'upload' subcommand is deprecated: pass it after")
+            log.warning(
+                "Passing --repository before the 'upload' subcommand is deprecated: pass it after"
+            )
         repository = args.repository or args.deprecated_repository
         from .upload import main
-        main(args.ini_file, repository, args.pypirc, formats=set(args.format or []),
-                gen_setup_py=gen_setup_py(), use_vcs=sdist_use_vcs())
 
-    elif args.subcmd == 'install':
+        main(
+            args.ini_file,
+            repository,
+            args.pypirc,
+            formats=set(args.format or []),
+            gen_setup_py=gen_setup_py(),
+            use_vcs=sdist_use_vcs(),
+        )
+
+    elif args.subcmd == "install":
         from .install import Installer
+
         try:
             python = find_python_executable(args.python)
             installer = Installer.from_ini_path(
@@ -211,17 +272,23 @@ def main(argv=None):
                 symlink=args.symlink,
                 deps=args.deps,
                 extras=args.extras,
-                pth=args.pth_file
+                pth=args.pth_file,
             )
             if args.only_deps:
                 installer.install_requirements()
             else:
                 installer.install()
-        except (ConfigError, PythonNotFoundError, common.NoDocstringError, common.NoVersionError) as e:
+        except (
+            ConfigError,
+            PythonNotFoundError,
+            common.NoDocstringError,
+            common.NoVersionError,
+        ) as e:
             sys.exit(e.args[0])
 
-    elif args.subcmd == 'init':
+    elif args.subcmd == "init":
         from .init import TerminalIniter
+
         TerminalIniter().initialise()
     else:
         ap.print_help()

--- a/flit/config.py
+++ b/flit/config.py
@@ -6,13 +6,15 @@ from .validate import validate_config
 
 
 def read_flit_config(path):
-    """Read and check the `pyproject.toml` or `flit.ini` file with data about the package.
-    """
+    """Read and check the `pyproject.toml` or `flit.ini` file with data about the package."""
+
     res = _read_flit_config_core(path)
 
     if validate_config(res):
-        if os.environ.get('FLIT_ALLOW_INVALID'):
-            log.warning("Allowing invalid data (FLIT_ALLOW_INVALID set). Uploads may still fail.")
+        if os.environ.get("FLIT_ALLOW_INVALID"):
+            log.warning(
+                "Allowing invalid data (FLIT_ALLOW_INVALID set). Uploads may still fail."
+            )
         else:
             raise ConfigError("Invalid config values (see log)")
     return res

--- a/flit/install.py
+++ b/flit/install.py
@@ -21,48 +21,51 @@ from ._get_dirs import get_dirs
 
 log = logging.getLogger(__name__)
 
+
 def _requires_dist_to_pip_requirement(requires_dist):
     """Parse "Foo (v); python_version == '2.x'" from Requires-Dist
 
     Returns pip-style appropriate for requirements.txt.
     """
-    env_mark = ''
-    if ';' in requires_dist:
-        name_version, env_mark = requires_dist.split(';', 1)
+    env_mark = ""
+    if ";" in requires_dist:
+        name_version, env_mark = requires_dist.split(";", 1)
     else:
         name_version = requires_dist
-    if '(' in name_version:
+    if "(" in name_version:
         # turn 'name (X)' and 'name (<X.Y)'
         # into 'name == X' and 'name < X.Y'
-        name, version = name_version.split('(', 1)
+        name, version = name_version.split("(", 1)
         name = name.strip()
-        version = version.replace(')', '').strip()
-        if not any(c in version for c in '=<>'):
-            version = '==' + version
+        version = version.replace(")", "").strip()
+        if not any(c in version for c in "=<>"):
+            version = "==" + version
         name_version = name + version
     # re-add environment marker
-    return ' ;'.join([name_version, env_mark])
+    return " ;".join([name_version, env_mark])
+
 
 def test_writable_dir(path):
     """Check if a directory is writable.
 
     Uses os.access() on POSIX, tries creating files on Windows.
     """
-    if os.name == 'posix':
+    if os.name == "posix":
         return os.access(path, os.W_OK)
 
     return _test_writable_dir_win(path)
 
+
 def _test_writable_dir_win(path):
     # os.access doesn't work on Windows: http://bugs.python.org/issue2528
     # and we can't use tempfile: http://bugs.python.org/issue22107
-    basename = 'accesstest_deleteme_fishfingers_custard_'
-    alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789'
+    basename = "accesstest_deleteme_fishfingers_custard_"
+    alphabet = "abcdefghijklmnopqrstuvwxyz0123456789"
     for i in range(10):
-        name = basename + ''.join(random.choice(alphabet) for _ in range(6))
+        name = basename + "".join(random.choice(alphabet) for _ in range(6))
         file = osp.join(path, name)
         try:
-            with open(file, mode='xb'):
+            with open(file, mode="xb"):
                 pass
         except FileExistsError:
             continue
@@ -76,22 +79,38 @@ def _test_writable_dir_win(path):
             return True
 
     # This should never be reached
-    msg = ('Unexpected condition testing for writable directory {!r}. '
-           'Please open an issue on flit to debug why this occurred.') # pragma: no cover
+    msg = (
+        "Unexpected condition testing for writable directory {!r}. "
+        "Please open an issue on flit to debug why this occurred."
+    )  # pragma: no cover
     raise EnvironmentError(msg.format(path))  # pragma: no cover
+
 
 class RootInstallError(Exception):
     def __str__(self):
-        return ("Installing packages as root is not recommended. "
-            "To allow this, set FLIT_ROOT_INSTALL=1 and try again.")
+        return (
+            "Installing packages as root is not recommended. "
+            "To allow this, set FLIT_ROOT_INSTALL=1 and try again."
+        )
+
 
 class DependencyError(Exception):
     def __str__(self):
-        return 'To install dependencies for extras, you cannot set deps=none.'
+        return "To install dependencies for extras, you cannot set deps=none."
+
 
 class Installer(object):
-    def __init__(self, directory, ini_info, user=None, python=sys.executable,
-                 symlink=False, deps='all', extras=(), pth=False):
+    def __init__(
+        self,
+        directory,
+        ini_info,
+        user=None,
+        python=sys.executable,
+        symlink=False,
+        deps="all",
+        extras=(),
+        pth=False,
+    ):
         self.directory = directory
         self.ini_info = ini_info
         self.python = python
@@ -99,50 +118,77 @@ class Installer(object):
         self.pth = pth
         self.deps = deps
         self.extras = extras
-        if deps != 'none' and os.environ.get('FLIT_NO_NETWORK', ''):
-            self.deps = 'none'
-            log.warning('Not installing dependencies, because FLIT_NO_NETWORK is set')
-        if deps == 'none' and extras:
+        if deps != "none" and os.environ.get("FLIT_NO_NETWORK", ""):
+            self.deps = "none"
+            log.warning("Not installing dependencies, because FLIT_NO_NETWORK is set")
+        if deps == "none" and extras:
             raise DependencyError()
 
-        self.module = common.Module(self.ini_info.module, directory)
+        try:
+            self.module = common.Module(self.ini_info.module, directory)
+        except AttributeError as exec:
+            if os.environ.get("FLIT_ALLOW_INVALID"):
+                log.warning(
+                    "Allowing invalid data (FLIT_ALLOW_INVALID set). Uploads may still fail."
+                )
+            else:
+                raise ValueError() from exec
 
-        if (hasattr(os, 'getuid') and (os.getuid() == 0) and
-                (not os.environ.get('FLIT_ROOT_INSTALL'))):
+        if (
+            hasattr(os, "getuid")
+            and (os.getuid() == 0)
+            and (not os.environ.get("FLIT_ROOT_INSTALL"))
+        ):
             raise RootInstallError
 
         if user is None:
             self.user = self._auto_user(python)
         else:
             self.user = user
-        log.debug('User install? %s', self.user)
+        log.debug("User install? %s", self.user)
 
         self.installed_files = []
 
     @classmethod
-    def from_ini_path(cls, ini_path, user=None, python=sys.executable,
-                      symlink=False, deps='all', extras=(), pth=False):
+    def from_ini_path(
+        cls,
+        ini_path,
+        user=None,
+        python=sys.executable,
+        symlink=False,
+        deps="all",
+        extras=(),
+        pth=False,
+    ):
         ini_info = read_flit_config(ini_path)
-        return cls(ini_path.parent, ini_info, user=user, python=python,
-                   symlink=symlink, deps=deps, extras=extras, pth=pth)
+        return cls(
+            ini_path.parent,
+            ini_info,
+            user=user,
+            python=python,
+            symlink=symlink,
+            deps=deps,
+            extras=extras,
+            pth=pth,
+        )
 
     def _run_python(self, code=None, file=None, extra_args=()):
         if code and file:
-            raise ValueError('Specify code or file, not both')
+            raise ValueError("Specify code or file, not both")
         if not (code or file):
-            raise ValueError('Specify code or file')
+            raise ValueError("Specify code or file")
 
         if code:
-            args = [self.python, '-c', code]
+            args = [self.python, "-c", code]
         else:
             args = [self.python, file]
         args.extend(extra_args)
         env = os.environ.copy()
-        env['PYTHONIOENCODING'] = 'utf-8'
+        env["PYTHONIOENCODING"] = "utf-8"
         # On Windows, shell needs to be True to pick up our local PATH
         # when finding the Python command.
-        shell = (os.name == 'nt')
-        return check_output(args, shell=shell, env=env).decode('utf-8')
+        shell = os.name == "nt"
+        return check_output(args, shell=shell, env=env).decode("utf-8")
 
     def _auto_user(self, python):
         """Default guess for whether to do user-level install.
@@ -151,47 +197,53 @@ class Installer(object):
         """
         if python == sys.executable:
             user_site = site.ENABLE_USER_SITE
-            lib_dir = sysconfig.get_path('purelib')
+            lib_dir = sysconfig.get_path("purelib")
         else:
-            out = self._run_python(code=
-                ("import sysconfig, site; "
-                 "print(site.ENABLE_USER_SITE); "
-                 "print(sysconfig.get_path('purelib'))"))
-            user_site, lib_dir = out.split('\n', 1)
-            user_site = (user_site.strip() == 'True')
+            out = self._run_python(
+                code=(
+                    "import sysconfig, site; "
+                    "print(site.ENABLE_USER_SITE); "
+                    "print(sysconfig.get_path('purelib'))"
+                )
+            )
+            user_site, lib_dir = out.split("\n", 1)
+            user_site = user_site.strip() == "True"
             lib_dir = lib_dir.strip()
 
         if not user_site:
             # No user site packages - probably a virtualenv
-            log.debug('User site packages not available - env install')
+            log.debug("User site packages not available - env install")
             return False
 
-        log.debug('Checking access to %s', lib_dir)
+        log.debug("Checking access to %s", lib_dir)
         return not test_writable_dir(lib_dir)
 
     def install_scripts(self, script_defs, scripts_dir):
         for name, ep in script_defs.items():
             module, func = common.parse_entry_point(ep)
-            import_name = func.split('.')[0]
+            import_name = func.split(".")[0]
             script_file = pathlib.Path(scripts_dir) / name
-            log.info('Writing script to %s', script_file)
-            with script_file.open('w', encoding='utf-8') as f:
-                f.write(common.script_template.format(
-                    interpreter=self.python,
-                    module=module,
-                    import_name=import_name,
-                    func=func
-                ))
+            log.info("Writing script to %s", script_file)
+            with script_file.open("w", encoding="utf-8") as f:
+                f.write(
+                    common.script_template.format(
+                        interpreter=self.python,
+                        module=module,
+                        import_name=import_name,
+                        func=func,
+                    )
+                )
             script_file.chmod(0o755)
 
             self.installed_files.append(script_file)
 
-            if sys.platform == 'win32':
-                cmd_file = script_file.with_suffix('.cmd')
+            if sys.platform == "win32":
+                cmd_file = script_file.with_suffix(".cmd")
                 cmd = '@echo off\r\n"{python}" "%~dp0\\{script}" %*\r\n'.format(
-                            python=self.python, script=name)
+                    python=self.python, script=name
+                )
                 log.debug("Writing script wrapper to %s", cmd_file)
-                with cmd_file.open('w') as f:
+                with cmd_file.open("w") as f:
                     f.write(cmd)
 
                 self.installed_files.append(cmd_file)
@@ -214,15 +266,15 @@ class Installer(object):
 
     def _extras_to_install(self):
         extras_to_install = set(self.extras)
-        if self.deps == 'all' or 'all' in extras_to_install:
+        if self.deps == "all" or "all" in extras_to_install:
             extras_to_install |= set(self.ini_info.reqs_by_extra.keys())
             # We don’t remove 'all' from the set because there might be an extra called “all”.
-        elif self.deps == 'develop':
-            extras_to_install |= {'dev', 'doc', 'test'}
+        elif self.deps == "develop":
+            extras_to_install |= {"dev", "doc", "test"}
 
-        if self.deps != 'none':
+        if self.deps != "none":
             # '.none' is an internal token for normal requirements
-            extras_to_install.add('.none')
+            extras_to_install.add(".none")
         log.info("Extras to install for deps %r: %s", self.deps, extras_to_install)
         return extras_to_install
 
@@ -234,7 +286,7 @@ class Installer(object):
         # construct the full list of requirements, including dev requirements
         requirements = []
 
-        if self.deps == 'none':
+        if self.deps == "none":
             return
 
         for extra in self._extras_to_install():
@@ -245,19 +297,18 @@ class Installer(object):
             return
 
         requirements = [
-            _requires_dist_to_pip_requirement(req_d)
-            for req_d in requirements
+            _requires_dist_to_pip_requirement(req_d) for req_d in requirements
         ]
 
         # install the requirements with pip
-        cmd = [self.python, '-m', 'pip', 'install']
+        cmd = [self.python, "-m", "pip", "install"]
         if self.user:
-            cmd.append('--user')
-        with tempfile.NamedTemporaryFile(mode='w',
-                                         suffix='requirements.txt',
-                                         delete=False) as tf:
-            tf.file.write('\n'.join(requirements))
-        cmd.extend(['-r', tf.name])
+            cmd.append("--user")
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix="requirements.txt", delete=False
+        ) as tf:
+            tf.file.write("\n".join(requirements))
+        cmd.extend(["-r", tf.name])
         log.info("Installing requirements")
         try:
             check_call(cmd)
@@ -274,12 +325,12 @@ class Installer(object):
         try:
             common.get_info_from_module(self.module, self.ini_info.dynamic_metadata)
         except ImportError:
-            if self.deps == 'none':
+            if self.deps == "none":
                 raise  # We were asked not to install deps, so bail out.
 
             log.warning("Installing requirements to Flit's env to import module.")
             user = self.user if (self.python == sys.executable) else None
-            i2 = Installer(self.directory, self.ini_info, user=user, deps='production')
+            i2 = Installer(self.directory, self.ini_info, user=user, deps="production")
             i2.install_requirements()
 
     def _get_dirs(self, user):
@@ -287,19 +338,19 @@ class Installer(object):
             return get_dirs(user=user)
         else:
             import json
-            path = osp.join(osp.dirname(__file__), '_get_dirs.py')
-            args = ['--user'] if user else []
+
+            path = osp.join(osp.dirname(__file__), "_get_dirs.py")
+            args = ["--user"] if user else []
             return json.loads(self._run_python(file=path, extra_args=args))
 
     def install_directly(self):
-        """Install a module/package into site-packages, and create its scripts.
-        """
+        """Install a module/package into site-packages, and create its scripts."""
         dirs = self._get_dirs(user=self.user)
-        os.makedirs(dirs['purelib'], exist_ok=True)
-        os.makedirs(dirs['scripts'], exist_ok=True)
+        os.makedirs(dirs["purelib"], exist_ok=True)
+        os.makedirs(dirs["scripts"], exist_ok=True)
 
         module_rel_path = self.module.path.relative_to(self.module.source_dir)
-        dst = osp.join(dirs['purelib'], module_rel_path)
+        dst = osp.join(dirs["purelib"], module_rel_path)
         if osp.lexists(dst):
             if osp.isdir(dst) and not osp.islink(dst):
                 shutil.rmtree(dst)
@@ -326,9 +377,9 @@ class Installer(object):
         elif self.pth:
             # .pth points to the the folder containing the module (which is
             # added to sys.path)
-            pth_file = pathlib.Path(dirs['purelib'], self.module.name + '.pth')
+            pth_file = pathlib.Path(dirs["purelib"], self.module.name + ".pth")
             log.info("Adding .pth file %s for %s", pth_file, self.module.source_dir)
-            pth_file.write_text(str(self.module.source_dir.resolve()), 'utf-8')
+            pth_file.write_text(str(self.module.source_dir.resolve()), "utf-8")
             self.installed_files.append(pth_file)
         elif self.module.is_package:
             log.info("Copying directory %s -> %s", src, dst)
@@ -340,12 +391,12 @@ class Installer(object):
             shutil.copy2(src, dst)
             self.installed_files.append(dst)
 
-        scripts = self.ini_info.entrypoints.get('console_scripts', {})
-        self.install_scripts(scripts, dirs['scripts'])
+        scripts = self.ini_info.entrypoints.get("console_scripts", {})
+        self.install_scripts(scripts, dirs["scripts"])
 
-        self.install_data_dir(dirs['data'])
+        self.install_data_dir(dirs["data"])
 
-        self.write_dist_info(dirs['purelib'])
+        self.write_dist_info(dirs["purelib"])
 
     def install_with_pip(self):
         """Let pip install the project directory
@@ -358,64 +409,69 @@ class Installer(object):
         """
         self.install_reqs_my_python_if_needed()
         extras = self._extras_to_install()
-        extras.discard('.none')
-        req_with_extras = '{}[{}]'.format(self.directory, ','.join(extras)) \
-            if extras else str(self.directory)
-        cmd = [self.python, '-m', 'pip', 'install', req_with_extras]
+        extras.discard(".none")
+        req_with_extras = (
+            "{}[{}]".format(self.directory, ",".join(extras))
+            if extras
+            else str(self.directory)
+        )
+        cmd = [self.python, "-m", "pip", "install", req_with_extras]
         if self.user:
-            cmd.append('--user')
-        if self.deps == 'none':
-            cmd.append('--no-deps')
-        shell = (os.name == 'nt')
+            cmd.append("--user")
+        if self.deps == "none":
+            cmd.append("--no-deps")
+        shell = os.name == "nt"
         check_call(cmd, shell=shell)
 
     def write_dist_info(self, site_pkgs):
         """Write dist-info folder, according to PEP 376"""
         metadata = common.make_metadata(self.module, self.ini_info)
         dist_info = pathlib.Path(site_pkgs) / common.dist_info_name(
-                                                metadata.name, metadata.version)
+            metadata.name, metadata.version
+        )
         try:
             dist_info.mkdir()
         except FileExistsError:
             shutil.rmtree(str(dist_info))
             dist_info.mkdir()
 
-        with (dist_info / 'METADATA').open('w', encoding='utf-8') as f:
+        with (dist_info / "METADATA").open("w", encoding="utf-8") as f:
             metadata.write_metadata_file(f)
-        self.installed_files.append(dist_info / 'METADATA')
+        self.installed_files.append(dist_info / "METADATA")
 
-        with (dist_info / 'INSTALLER').open('w', encoding='utf-8') as f:
-            f.write('flit')
-        self.installed_files.append(dist_info / 'INSTALLER')
+        with (dist_info / "INSTALLER").open("w", encoding="utf-8") as f:
+            f.write("flit")
+        self.installed_files.append(dist_info / "INSTALLER")
 
         # We only handle explicitly requested installations
-        with (dist_info / 'REQUESTED').open('wb'): pass
-        self.installed_files.append(dist_info / 'REQUESTED')
+        with (dist_info / "REQUESTED").open("wb"):
+            pass
+        self.installed_files.append(dist_info / "REQUESTED")
 
         if self.ini_info.entrypoints:
-            with (dist_info / 'entry_points.txt').open('w') as f:
+            with (dist_info / "entry_points.txt").open("w") as f:
                 common.write_entry_points(self.ini_info.entrypoints, f)
-            self.installed_files.append(dist_info / 'entry_points.txt')
+            self.installed_files.append(dist_info / "entry_points.txt")
 
-        with (dist_info / 'direct_url.json').open('w', encoding='utf-8') as f:
+        with (dist_info / "direct_url.json").open("w", encoding="utf-8") as f:
             json.dump(
                 {
                     "url": self.directory.resolve().as_uri(),
-                    "dir_info": {"editable": bool(self.symlink or self.pth)}
+                    "dir_info": {"editable": bool(self.symlink or self.pth)},
                 },
-                f
+                f,
             )
-        self.installed_files.append(dist_info / 'direct_url.json')
+        self.installed_files.append(dist_info / "direct_url.json")
 
         # newline='' because the csv module does its own newline translation
-        with (dist_info / 'RECORD').open('w', encoding='utf-8', newline='') as f:
+        with (dist_info / "RECORD").open("w", encoding="utf-8", newline="") as f:
             cf = csv.writer(f)
             for path in sorted(self.installed_files, key=str):
                 path = pathlib.Path(path)
-                if path.is_symlink() or path.suffix in {'.pyc', '.pyo'}:
-                    hash, size = '', ''
+                if path.is_symlink() or path.suffix in {".pyc", ".pyo"}:
+                    hash, size = "", ""
                 else:
-                    hash = 'sha256=' + common.hash_file(str(path))
+                    hash = "sha256=" + common.hash_file(str(path))
                     size = path.stat().st_size
                 try:
                     path = path.relative_to(site_pkgs)
@@ -423,10 +479,25 @@ class Installer(object):
                     pass
                 cf.writerow((str(path), hash, size))
 
-            cf.writerow(((dist_info / 'RECORD').relative_to(site_pkgs), '', ''))
+            cf.writerow(((dist_info / "RECORD").relative_to(site_pkgs), "", ""))
 
     def install(self):
         if self.symlink or self.pth:
             self.install_directly()
         else:
             self.install_with_pip()
+
+
+class DependencyInstaller(Installer):
+    def __init__(
+        self,
+        directory,
+        ini_info,
+        user=None,
+        python=sys.executable,
+        symlink=False,
+        deps="all",
+        extras=(),
+        pth=False,
+    ):
+        super().__init__(directory, ini_info, user, python, symlink, deps, extras, pth)

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -12,9 +12,10 @@ log = logging.getLogger(__name__)
 
 from .versionno import normalise_version
 
+
 class Module(object):
-    """This represents the module/package that we are going to distribute
-    """
+    """This represents the module/package that we are going to distribute"""
+
     in_namespace_package = False
     namespace_package_name = None
 
@@ -22,52 +23,58 @@ class Module(object):
         self.name = name
 
         # It must exist either as a .py file or a directory, but not both
-        name_as_path = name.replace('.', os.sep)
+        name_as_path = name.replace(".", os.sep)
         pkg_dir = directory / name_as_path
-        py_file = directory / (name_as_path+'.py')
-        src_pkg_dir = directory / 'src' / name_as_path
-        src_py_file = directory / 'src' / (name_as_path+'.py')
+        py_file = directory / (name_as_path + ".py")
+        src_pkg_dir = directory / "src" / name_as_path
+        src_py_file = directory / "src" / (name_as_path + ".py")
 
         existing = set()
         if pkg_dir.is_dir():
             self.path = pkg_dir
             self.is_package = True
-            self.prefix = ''
+            self.prefix = ""
             existing.add(pkg_dir)
         if py_file.is_file():
             self.path = py_file
             self.is_package = False
-            self.prefix = ''
+            self.prefix = ""
             existing.add(py_file)
         if src_pkg_dir.is_dir():
             self.path = src_pkg_dir
             self.is_package = True
-            self.prefix = 'src'
+            self.prefix = "src"
             existing.add(src_pkg_dir)
         if src_py_file.is_file():
             self.path = src_py_file
             self.is_package = False
-            self.prefix = 'src'
+            self.prefix = "src"
             existing.add(src_py_file)
 
         if len(existing) > 1:
             raise ValueError(
-                "Multiple files or folders could be module {}: {}"
-                .format(name, ", ".join([str(p) for p in sorted(existing)]))
+                "Multiple files or folders could be module {}: {}".format(
+                    name, ", ".join([str(p) for p in sorted(existing)])
+                )
             )
         elif not existing:
-            raise ValueError("No file/folder found for module {}".format(name))
+            if os.environ.get("FLIT_ALLOW_INVALID"):
+                log.warning(
+                    "Allowing invalid data (FLIT_ALLOW_INVALID set). Uploads may still fail."
+                )
+            else:
+                raise ValueError("No file/folder found for module {}".format(name))
 
         self.source_dir = directory / self.prefix
 
-        if '.' in name:
-            self.namespace_package_name = name.rpartition('.')[0]
+        if "." in name:
+            self.namespace_package_name = name.rpartition(".")[0]
             self.in_namespace_package = True
 
     @property
     def file(self):
         if self.is_package:
-            return self.path / '__init__.py'
+            return self.path / "__init__.py"
         else:
             return self.path
 
@@ -77,9 +84,10 @@ class Module(object):
         Yields absolute paths - caller may want to make them relative.
         Excludes any __pycache__ and *.pyc files.
         """
+
         def _include(path):
             name = os.path.basename(path)
-            if (name == '__pycache__') or name.endswith('.pyc'):
+            if (name == "__pycache__") or name.endswith(".pyc"):
                 return False
             return True
 
@@ -96,10 +104,22 @@ class Module(object):
         else:
             yield str(self.path)
 
-class ProblemInModule(ValueError): pass
-class NoDocstringError(ProblemInModule): pass
-class NoVersionError(ProblemInModule): pass
-class InvalidVersion(ProblemInModule): pass
+
+class ProblemInModule(ValueError):
+    pass
+
+
+class NoDocstringError(ProblemInModule):
+    pass
+
+
+class NoVersionError(ProblemInModule):
+    pass
+
+
+class InvalidVersion(ProblemInModule):
+    pass
+
 
 class VCSError(Exception):
     def __init__(self, msg, directory):
@@ -107,7 +127,7 @@ class VCSError(Exception):
         self.directory = directory
 
     def __str__(self):
-        return self.msg + ' ({})'.format(self.directory)
+        return self.msg + " ({})".format(self.directory)
 
 
 @contextmanager
@@ -122,25 +142,25 @@ def _module_load_ctx():
     finally:
         logging.root.handlers = logging_handlers
 
+
 def get_docstring_and_version_via_ast(target):
     """
     Return a tuple like (docstring, version) for the given module,
     extracted by parsing its AST.
     """
     # read as bytes to enable custom encodings
-    with target.file.open('rb') as f:
+    with target.file.open("rb") as f:
         node = ast.parse(f.read())
     for child in node.body:
         # Only use the version from the given module if it's a simple
         # string assignment to __version__
         is_version_str = (
-                isinstance(child, ast.Assign)
-                and any(
-                    isinstance(target, ast.Name)
-                    and target.id == "__version__"
-                    for target in child.targets
-                )
-                and isinstance(child.value, ast.Str)
+            isinstance(child, ast.Assign)
+            and any(
+                isinstance(target, ast.Name) and target.id == "__version__"
+                for target in child.targets
+            )
+            and isinstance(child.value, ast.Str)
         )
         if is_version_str:
             version = child.value.s
@@ -167,7 +187,8 @@ def get_docstring_and_version_via_import(target):
 
     log.debug("Loading module %s", target.file)
     from importlib.util import spec_from_file_location, module_from_spec
-    mod_name = 'flit_core.dummy.import%d' % _import_i
+
+    mod_name = "flit_core.dummy.import%d" % _import_i
     spec = spec_from_file_location(mod_name, target.file)
     with _module_load_ctx():
         m = module_from_spec(spec)
@@ -181,20 +202,19 @@ def get_docstring_and_version_via_import(target):
         finally:
             sys.modules.pop(mod_name, None)
 
-    docstring = m.__dict__.get('__doc__', None)
-    version = m.__dict__.get('__version__', None)
+    docstring = m.__dict__.get("__doc__", None)
+    version = m.__dict__.get("__version__", None)
     return docstring, version
 
 
-def get_info_from_module(target, for_fields=('version', 'description')):
-    """Load the module/package, get its docstring and __version__
-    """
+def get_info_from_module(target, for_fields=("version", "description")):
+    """Load the module/package, get its docstring and __version__"""
     if not for_fields:
         return {}
 
     # What core metadata calls Summary, PEP 621 calls description
-    want_summary = 'description' in for_fields
-    want_version = 'version' in for_fields
+    want_summary = "description" in for_fields
+    want_version = "version" in for_fields
 
     log.debug("Loading module %s", target.file)
 
@@ -211,15 +231,16 @@ def get_info_from_module(target, for_fields=('version', 'description')):
     if want_summary:
         if (not docstring) or not docstring.strip():
             raise NoDocstringError(
-                'Flit cannot package module without docstring, or empty docstring. '
-                'Please add a docstring to your module ({}).'.format(target.file)
+                "Flit cannot package module without docstring, or empty docstring. "
+                "Please add a docstring to your module ({}).".format(target.file)
             )
-        res['summary'] = docstring.lstrip().splitlines()[0]
+        res["summary"] = docstring.lstrip().splitlines()[0]
 
     if want_version:
-        res['version'] = check_version(version)
+        res["version"] = check_version(version)
 
     return res
+
 
 def check_version(version):
     """
@@ -233,11 +254,14 @@ def check_version(version):
     Returns the version in canonical PEP 440 format.
     """
     if not version:
-        raise NoVersionError('Cannot package module without a version string. '
-                             'Please define a `__version__ = "x.y.z"` in your module.')
+        raise NoVersionError(
+            "Cannot package module without a version string. "
+            'Please define a `__version__ = "x.y.z"` in your module.'
+        )
     if not isinstance(version, str):
-        raise InvalidVersion('__version__ must be a string, not {}.'
-                                .format(type(version)))
+        raise InvalidVersion(
+            "__version__ must be a string, not {}.".format(type(version))
+        )
 
     # Import here to avoid circular import
     version = normalise_version(version)
@@ -256,23 +280,25 @@ if __name__ == '__main__':
     sys.exit({func}())
 """
 
+
 def parse_entry_point(ep):
     """Check and parse a 'package.module:func' style entry point specification.
 
     Returns (modulename, funcname)
     """
-    if ':' not in ep:
+    if ":" not in ep:
         raise ValueError("Invalid entry point (no ':'): %r" % ep)
-    mod, func = ep.split(':')
+    mod, func = ep.split(":")
 
-    for piece in func.split('.'):
+    for piece in func.split("."):
         if not piece.isidentifier():
             raise ValueError("Invalid entry point: %r is not an identifier" % piece)
-    for piece in mod.split('.'):
+    for piece in mod.split("."):
         if not piece.isidentifier():
             raise ValueError("Invalid entry point: %r is not a module path" % piece)
 
     return mod, func
+
 
 def write_entry_points(d, fp):
     """Write entry_points.txt from a two-level dict
@@ -280,17 +306,19 @@ def write_entry_points(d, fp):
     Sorts on keys to ensure results are reproducible.
     """
     for group_name in sorted(d):
-        fp.write(u'[{}]\n'.format(group_name))
+        fp.write("[{}]\n".format(group_name))
         group = d[group_name]
         for name in sorted(group):
             val = group[name]
-            fp.write(u'{}={}\n'.format(name, val))
-        fp.write(u'\n')
+            fp.write("{}={}\n".format(name, val))
+        fp.write("\n")
 
-def hash_file(path, algorithm='sha256'):
-    with open(path, 'rb') as f:
+
+def hash_file(path, algorithm="sha256"):
+    with open(path, "rb") as f:
         h = hashlib.new(algorithm, f.read())
     return h.hexdigest()
+
 
 def normalize_file_permissions(st_mode):
     """Normalize the permission bits in the st_mode field from stat to 644/755
@@ -305,8 +333,8 @@ def normalize_file_permissions(st_mode):
         new_mode |= 0o111  # Executable: 644 -> 755
     return new_mode
 
-class Metadata(object):
 
+class Metadata(object):
     summary = None
     home_page = None
     author = None
@@ -337,39 +365,39 @@ class Metadata(object):
 
     def __init__(self, data):
         data = data.copy()
-        self.name = data.pop('name')
-        self.version = data.pop('version')
+        self.name = data.pop("name")
+        self.version = data.pop("version")
 
         for k, v in data.items():
             assert hasattr(self, k), "data does not have attribute '{}'".format(k)
             setattr(self, k, v)
 
     def _normalise_name(self, n):
-        return n.lower().replace('-', '_')
+        return n.lower().replace("-", "_")
 
     def write_metadata_file(self, fp):
         """Write out metadata in the email headers format"""
         fields = [
-            'Metadata-Version',
-            'Name',
-            'Version',
+            "Metadata-Version",
+            "Name",
+            "Version",
         ]
         optional_fields = [
-            'Summary',
-            'Home-page',
-            'License',
-            'Keywords',
-            'Author',
-            'Author-email',
-            'Maintainer',
-            'Maintainer-email',
-            'Requires-Python',
-            'Description-Content-Type',
+            "Summary",
+            "Home-page",
+            "License",
+            "Keywords",
+            "Author",
+            "Author-email",
+            "Maintainer",
+            "Maintainer-email",
+            "Requires-Python",
+            "Description-Content-Type",
         ]
 
         for field in fields:
             value = getattr(self, self._normalise_name(field))
-            fp.write(u"{}: {}\n".format(field, value))
+            fp.write("{}: {}\n".format(field, value))
 
         for field in optional_fields:
             value = getattr(self, self._normalise_name(field))
@@ -378,23 +406,23 @@ class Metadata(object):
                 # The spec has multiline examples for Author, Maintainer &
                 # License (& Description, but we put that in the body)
                 # Indent following lines with 8 spaces:
-                value = '\n        '.join(value.splitlines())
-                fp.write(u"{}: {}\n".format(field, value))
+                value = "\n        ".join(value.splitlines())
+                fp.write("{}: {}\n".format(field, value))
 
         for clsfr in self.classifiers:
-            fp.write(u'Classifier: {}\n'.format(clsfr))
+            fp.write("Classifier: {}\n".format(clsfr))
 
         for req in self.requires_dist:
-            fp.write(u'Requires-Dist: {}\n'.format(req))
+            fp.write("Requires-Dist: {}\n".format(req))
 
         for url in self.project_urls:
-            fp.write(u'Project-URL: {}\n'.format(url))
+            fp.write("Project-URL: {}\n".format(url))
 
         for extra in self.provides_extra:
-            fp.write(u'Provides-Extra: {}\n'.format(extra))
+            fp.write("Provides-Extra: {}\n".format(extra))
 
         if self.description is not None:
-            fp.write(u'\n' + self.description + u'\n')
+            fp.write("\n" + self.description + "\n")
 
     @property
     def supports_py2(self):
@@ -406,11 +434,10 @@ class Metadata(object):
 
 
 def make_metadata(module, ini_info):
-    md_dict = {'name': module.name, 'provides': [module.name]}
+    md_dict = {"name": module.name, "provides": [module.name]}
     md_dict.update(get_info_from_module(module, ini_info.dynamic_metadata))
     md_dict.update(ini_info.metadata)
     return Metadata(md_dict)
-
 
 
 def normalize_dist_name(name: str, version: str) -> str:
@@ -421,15 +448,15 @@ def normalize_dist_name(name: str, version: str) -> str:
 
     See https://packaging.python.org/specifications/binary-distribution-format/#escaping-and-unicode
     """
-    normalized_name = re.sub(r'[-_.]+', '_', name, flags=re.UNICODE).lower()
+    normalized_name = re.sub(r"[-_.]+", "_", name, flags=re.UNICODE).lower()
     assert check_version(version) == version
-    assert '-' not in version, 'Normalized versions can’t have dashes'
-    return '{}-{}'.format(normalized_name, version)
+    assert "-" not in version, "Normalized versions can’t have dashes"
+    return "{}-{}".format(normalized_name, version)
 
 
 def dist_info_name(distribution, version):
     """Get the correct name of the .dist-info folder"""
-    return normalize_dist_name(distribution, version) + '.dist-info'
+    return normalize_dist_name(distribution, version) + ".dist-info"
 
 
 def walk_data_dir(data_directory):
@@ -446,4 +473,4 @@ def walk_data_dir(data_directory):
             full_path = os.path.join(dirpath, file)
             yield full_path
 
-        dirs[:] = [d for d in sorted(dirs) if d != '__pycache__']
+        dirs[:] = [d for d in sorted(dirs) if d != "__pycache__"]

--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -25,137 +25,142 @@ log = logging.getLogger(__name__)
 class ConfigError(ValueError):
     pass
 
-metadata_list_fields = {
-    'classifiers',
-    'requires',
-    'dev-requires'
-}
+
+metadata_list_fields = {"classifiers", "requires", "dev-requires"}
 
 metadata_allowed_fields = {
-    'module',
-    'author',
-    'author-email',
-    'maintainer',
-    'maintainer-email',
-    'home-page',
-    'license',
-    'keywords',
-    'requires-python',
-    'dist-name',
-    'description-file',
-    'requires-extra',
+    "module",
+    "author",
+    "author-email",
+    "maintainer",
+    "maintainer-email",
+    "home-page",
+    "license",
+    "keywords",
+    "requires-python",
+    "dist-name",
+    "description-file",
+    "requires-extra",
 } | metadata_list_fields
 
 metadata_required_fields = {
-    'module',
-    'author',
+    "module",
+    "author",
 }
 
 pep621_allowed_fields = {
-    'name',
-    'version',
-    'description',
-    'readme',
-    'requires-python',
-    'license',
-    'authors',
-    'maintainers',
-    'keywords',
-    'classifiers',
-    'urls',
-    'scripts',
-    'gui-scripts',
-    'entry-points',
-    'dependencies',
-    'optional-dependencies',
-    'dynamic',
+    "name",
+    "version",
+    "description",
+    "readme",
+    "requires-python",
+    "license",
+    "authors",
+    "maintainers",
+    "keywords",
+    "classifiers",
+    "urls",
+    "scripts",
+    "gui-scripts",
+    "entry-points",
+    "dependencies",
+    "optional-dependencies",
+    "dynamic",
 }
 
 
 def read_flit_config(path):
-    """Read and check the `pyproject.toml` file with data about the package.
-    """
-    d = tomllib.loads(path.read_text('utf-8'))
+    """Read and check the `pyproject.toml` file with data about the package."""
+    d = tomllib.loads(path.read_text("utf-8"))
     return prep_toml_config(d, path)
 
 
 class EntryPointsConflict(ConfigError):
     def __str__(self):
-        return ('Please specify console_scripts entry points, or [scripts] in '
-            'flit config, not both.')
+        return (
+            "Please specify console_scripts entry points, or [scripts] in "
+            "flit config, not both."
+        )
+
 
 def prep_toml_config(d, path):
     """Validate config loaded from pyproject.toml and prepare common metadata
-    
+
     Returns a LoadedConfig object.
     """
-    dtool = d.get('tool', {}).get('flit', {})
+    dtool = d.get("tool", {}).get("flit", {})
 
-    if 'project' in d:
+    if "project" in d:
         # Metadata in [project] table (PEP 621)
-        if 'metadata' in dtool:
+        if "metadata" in dtool:
             raise ConfigError(
                 "Use [project] table for metadata or [tool.flit.metadata], not both."
             )
-        if ('scripts' in dtool) or ('entrypoints' in dtool):
+        if ("scripts" in dtool) or ("entrypoints" in dtool):
             raise ConfigError(
                 "Don't mix [project] metadata with [tool.flit.scripts] or "
                 "[tool.flit.entrypoints]. Use [project.scripts],"
                 "[project.gui-scripts] or [project.entry-points] as replacements."
             )
-        loaded_cfg = read_pep621_metadata(d['project'], path)
+        loaded_cfg = read_pep621_metadata(d["project"], path)
 
-        module_tbl = dtool.get('module', {})
-        if 'name' in module_tbl:
-            loaded_cfg.module = module_tbl['name']
-    elif 'metadata' in dtool:
+        module_tbl = dtool.get("module", {})
+        if "name" in module_tbl:
+            loaded_cfg.module = module_tbl["name"]
+    elif "metadata" in dtool:
         # Metadata in [tool.flit.metadata] (pre PEP 621 format)
-        if 'module' in dtool:
+        if "module" in dtool:
             raise ConfigError(
                 "Use [tool.flit.module] table with new-style [project] metadata, "
                 "not [tool.flit.metadata]"
             )
-        loaded_cfg = _prep_metadata(dtool['metadata'], path)
-        loaded_cfg.dynamic_metadata = ['version', 'description']
+        loaded_cfg = _prep_metadata(dtool["metadata"], path)
+        loaded_cfg.dynamic_metadata = ["version", "description"]
 
-        if 'entrypoints' in dtool:
-            loaded_cfg.entrypoints = flatten_entrypoints(dtool['entrypoints'])
+        if "entrypoints" in dtool:
+            loaded_cfg.entrypoints = flatten_entrypoints(dtool["entrypoints"])
 
-        if 'scripts' in dtool:
-            loaded_cfg.add_scripts(dict(dtool['scripts']))
+        if "scripts" in dtool:
+            loaded_cfg.add_scripts(dict(dtool["scripts"]))
     else:
         raise ConfigError(
             "Neither [project] nor [tool.flit.metadata] found in pyproject.toml"
         )
 
     unknown_sections = set(dtool) - {
-        'metadata', 'module', 'scripts', 'entrypoints', 'sdist', 'external-data'
+        "metadata",
+        "module",
+        "scripts",
+        "entrypoints",
+        "sdist",
+        "external-data",
     }
-    unknown_sections = [s for s in unknown_sections if not s.lower().startswith('x-')]
+    unknown_sections = [s for s in unknown_sections if not s.lower().startswith("x-")]
     if unknown_sections:
-        raise ConfigError('Unexpected tables in pyproject.toml: ' + ', '.join(
-            '[tool.flit.{}]'.format(s) for s in unknown_sections
-        ))
+        raise ConfigError(
+            "Unexpected tables in pyproject.toml: "
+            + ", ".join("[tool.flit.{}]".format(s) for s in unknown_sections)
+        )
 
-    if 'sdist' in dtool:
-        unknown_keys = set(dtool['sdist']) - {'include', 'exclude'}
+    if "sdist" in dtool:
+        unknown_keys = set(dtool["sdist"]) - {"include", "exclude"}
         if unknown_keys:
             raise ConfigError(
                 "Unknown keys in [tool.flit.sdist]:" + ", ".join(unknown_keys)
             )
 
         loaded_cfg.sdist_include_patterns = _check_glob_patterns(
-            dtool['sdist'].get('include', []), 'include'
+            dtool["sdist"].get("include", []), "include"
         )
         exclude = [
             "**/__pycache__",
             "**.pyc",
-        ] + dtool['sdist'].get('exclude', [])
-        loaded_cfg.sdist_exclude_patterns = _check_glob_patterns(
-            exclude, 'exclude'
-        )
+        ] + dtool[
+            "sdist"
+        ].get("exclude", [])
+        loaded_cfg.sdist_exclude_patterns = _check_glob_patterns(exclude, "exclude")
 
-    data_dir = dtool.get('external-data', {}).get('directory', None)
+    data_dir = dtool.get("external-data", {}).get("directory", None)
     if data_dir is not None:
         toml_key = "tool.flit.external-data.directory"
         if not isinstance(data_dir, str):
@@ -164,11 +169,11 @@ def prep_toml_config(d, path):
         normp = osp.normpath(data_dir)
         if osp.isabs(normp):
             raise ConfigError(f"{toml_key} cannot be an absolute path")
-        if normp.startswith('..' + os.sep):
+        if normp.startswith(".." + os.sep):
             raise ConfigError(
                 f"{toml_key} cannot point outside the directory containing pyproject.toml"
             )
-        if normp == '.':
+        if normp == ".":
             raise ConfigError(
                 f"{toml_key} cannot refer to the directory containing pyproject.toml"
             )
@@ -177,6 +182,7 @@ def prep_toml_config(d, path):
             raise ConfigError(f"{toml_key} must refer to a directory")
 
     return loaded_cfg
+
 
 def flatten_entrypoints(ep):
     """Flatten nested entrypoints dicts.
@@ -194,11 +200,12 @@ def flatten_entrypoints(ep):
     flit allows you to use the former. This flattens the nested dictionaries
     from loading pyproject.toml.
     """
+
     def _flatten(d, prefix):
         d1 = {}
         for k, v in d.items():
             if isinstance(v, dict):
-                for flattened in _flatten(v, prefix+'.'+k):
+                for flattened in _flatten(v, prefix + "." + k):
                     yield flattened
             else:
                 d1[k] = v
@@ -226,20 +233,20 @@ def _check_glob_patterns(pats, clude):
     for p in pats:
         if bad_chars.search(p):
             raise ConfigError(
-                '{} pattern {!r} contains bad characters (<>:\"\\ or control characters)'
-                .format(clude, p)
+                '{} pattern {!r} contains bad characters (<>:"\\ or control characters)'.format(
+                    clude, p
+                )
             )
 
         normp = osp.normpath(p)
 
         if osp.isabs(normp):
+            raise ConfigError("{} pattern {!r} is an absolute path".format(clude, p))
+        if normp.startswith(".." + os.sep):
             raise ConfigError(
-                '{} pattern {!r} is an absolute path'.format(clude, p)
-            )
-        if normp.startswith('..' + os.sep):
-            raise ConfigError(
-                '{} pattern {!r} points out of the directory containing pyproject.toml'
-                .format(clude, p)
+                "{} pattern {!r} points out of the directory containing pyproject.toml".format(
+                    clude, p
+                )
             )
         normed.append(normp)
 
@@ -260,15 +267,16 @@ class LoadedConfig(object):
 
     def add_scripts(self, scripts_dict):
         if scripts_dict:
-            if 'console_scripts' in self.entrypoints:
+            if "console_scripts" in self.entrypoints:
                 raise EntryPointsConflict
             else:
-                self.entrypoints['console_scripts'] = scripts_dict
+                self.entrypoints["console_scripts"] = scripts_dict
+
 
 readme_ext_to_content_type = {
-    '.rst': 'text/x-rst',
-    '.md': 'text/markdown',
-    '.txt': 'text/plain',
+    ".rst": "text/x-rst",
+    ".md": "text/markdown",
+    ".txt": "text/plain",
 }
 
 
@@ -278,13 +286,11 @@ def description_from_file(rel_path: str, proj_dir: Path, guess_mimetype=True):
 
     desc_path = proj_dir / rel_path
     try:
-        with desc_path.open('r', encoding='utf-8') as f:
+        with desc_path.open("r", encoding="utf-8") as f:
             raw_desc = f.read()
     except IOError as e:
         if e.errno == errno.ENOENT:
-            raise ConfigError(
-                "Description file {} does not exist".format(desc_path)
-            )
+            raise ConfigError("Description file {} does not exist".format(desc_path))
         raise
 
     if guess_mimetype:
@@ -293,8 +299,9 @@ def description_from_file(rel_path: str, proj_dir: Path, guess_mimetype=True):
             mimetype = readme_ext_to_content_type[ext]
         except KeyError:
             log.warning("Unknown extension %r for description file.", ext)
-            log.warning("  Recognised extensions: %s",
-                        " ".join(readme_ext_to_content_type))
+            log.warning(
+                "  Recognised extensions: %s", " ".join(readme_ext_to_content_type)
+            )
             mimetype = None
     else:
         mimetype = None
@@ -304,110 +311,128 @@ def description_from_file(rel_path: str, proj_dir: Path, guess_mimetype=True):
 
 def _prep_metadata(md_sect, path):
     """Process & verify the metadata from a config file
-    
+
     - Pull out the module name we're packaging.
     - Read description-file and check that it's valid rst
     - Convert dashes in key names to underscores
-      (e.g. home-page in config -> home_page in metadata) 
+      (e.g. home-page in config -> home_page in metadata)
     """
     if not set(md_sect).issuperset(metadata_required_fields):
         missing = metadata_required_fields - set(md_sect)
-        raise ConfigError("Required fields missing: " + '\n'.join(missing))
+        raise ConfigError("Required fields missing: " + "\n".join(missing))
 
     res = LoadedConfig()
 
-    res.module = md_sect.get('module')
+    res.module = md_sect.get("module")
     if not all([m.isidentifier() for m in res.module.split(".")]):
         raise ConfigError("Module name %r is not a valid identifier" % res.module)
 
     md_dict = res.metadata
 
     # Description file
-    if 'description-file' in md_sect:
-        desc_path = md_sect.get('description-file')
-        res.referenced_files.append(desc_path)
-        desc_content, mimetype = description_from_file(desc_path, path.parent)
-        md_dict['description'] =  desc_content
-        md_dict['description_content_type'] = mimetype
+    if "description-file" in md_sect:
+        try:
+            desc_path = md_sect.get("description-file")
+            res.referenced_files.append(desc_path)
+            desc_content, mimetype = description_from_file(desc_path, path.parent)
+            md_dict["description"] = desc_content
+            md_dict["description_content_type"] = mimetype
+        except ConfigError as ex:
+            if os.environ.get("FLIT_ALLOW_INVALID"):
+                log.warning(
+                    "Allowing invalid data (FLIT_ALLOW_INVALID set). Uploads may still fail."
+                )
+            else:
+                raise ConfigError("Invalid config values (see log)") from ex
 
-    if 'urls' in md_sect:
-        project_urls = md_dict['project_urls'] = []
-        for label, url in sorted(md_sect.pop('urls').items()):
+    if "urls" in md_sect:
+        project_urls = md_dict["project_urls"] = []
+        for label, url in sorted(md_sect.pop("urls").items()):
             project_urls.append("{}, {}".format(label, url))
 
     for key, value in md_sect.items():
-        if key in {'description-file', 'module'}:
+        if key in {"description-file", "module"}:
             continue
         if key not in metadata_allowed_fields:
-            closest = difflib.get_close_matches(key, metadata_allowed_fields,
-                                                n=1, cutoff=0.7)
+            closest = difflib.get_close_matches(
+                key, metadata_allowed_fields, n=1, cutoff=0.7
+            )
             msg = "Unrecognised metadata key: {!r}".format(key)
             if closest:
                 msg += " (did you mean {!r}?)".format(closest[0])
             raise ConfigError(msg)
 
-        k2 = key.replace('-', '_')
+        k2 = key.replace("-", "_")
         md_dict[k2] = value
         if key in metadata_list_fields:
             if not isinstance(value, list):
-                raise ConfigError('Expected a list for {} field, found {!r}'
-                                    .format(key, value))
+                raise ConfigError(
+                    "Expected a list for {} field, found {!r}".format(key, value)
+                )
             if not all(isinstance(a, str) for a in value):
-                raise ConfigError('Expected a list of strings for {} field'
-                                    .format(key))
-        elif key == 'requires-extra':
+                raise ConfigError("Expected a list of strings for {} field".format(key))
+        elif key == "requires-extra":
             if not isinstance(value, dict):
-                raise ConfigError('Expected a dict for requires-extra field, found {!r}'
-                                    .format(value))
+                raise ConfigError(
+                    "Expected a dict for requires-extra field, found {!r}".format(value)
+                )
             if not all(isinstance(e, list) for e in value.values()):
-                raise ConfigError('Expected a dict of lists for requires-extra field')
+                raise ConfigError("Expected a dict of lists for requires-extra field")
             for e, reqs in value.items():
                 if not all(isinstance(a, str) for a in reqs):
-                    raise ConfigError('Expected a string list for requires-extra. (extra {})'
-                                        .format(e))
+                    raise ConfigError(
+                        "Expected a string list for requires-extra. (extra {})".format(
+                            e
+                        )
+                    )
         else:
             if not isinstance(value, str):
-                raise ConfigError('Expected a string for {} field, found {!r}'
-                                    .format(key, value))
+                raise ConfigError(
+                    "Expected a string for {} field, found {!r}".format(key, value)
+                )
 
     # What we call requires in the ini file is technically requires_dist in
     # the metadata.
-    if 'requires' in md_dict:
-        md_dict['requires_dist'] = md_dict.pop('requires')
+    if "requires" in md_dict:
+        md_dict["requires_dist"] = md_dict.pop("requires")
 
     # And what we call dist-name is name in the metadata
-    if 'dist_name' in md_dict:
-        md_dict['name'] = md_dict.pop('dist_name')
+    if "dist_name" in md_dict:
+        md_dict["name"] = md_dict.pop("dist_name")
 
     # Move dev-requires into requires-extra
-    reqs_noextra = md_dict.pop('requires_dist', [])
-    res.reqs_by_extra = md_dict.pop('requires_extra', {})
-    dev_requires = md_dict.pop('dev_requires', None)
+    reqs_noextra = md_dict.pop("requires_dist", [])
+    res.reqs_by_extra = md_dict.pop("requires_extra", {})
+    dev_requires = md_dict.pop("dev_requires", None)
     if dev_requires is not None:
-        if 'dev' in res.reqs_by_extra:
+        if "dev" in res.reqs_by_extra:
             raise ConfigError(
-                'dev-requires occurs together with its replacement requires-extra.dev.')
+                "dev-requires occurs together with its replacement requires-extra.dev."
+            )
         else:
             log.warning(
-                '"dev-requires = ..." is obsolete. Use "requires-extra = {"dev" = ...}" instead.')
-            res.reqs_by_extra['dev'] = dev_requires
+                '"dev-requires = ..." is obsolete. Use "requires-extra = {"dev" = ...}" instead.'
+            )
+            res.reqs_by_extra["dev"] = dev_requires
 
     # Add requires-extra requirements into requires_dist
-    md_dict['requires_dist'] = \
-        reqs_noextra + list(_expand_requires_extra(res.reqs_by_extra))
+    md_dict["requires_dist"] = reqs_noextra + list(
+        _expand_requires_extra(res.reqs_by_extra)
+    )
 
-    md_dict['provides_extra'] = sorted(res.reqs_by_extra.keys())
+    md_dict["provides_extra"] = sorted(res.reqs_by_extra.keys())
 
     # For internal use, record the main requirements as a '.none' extra.
-    res.reqs_by_extra['.none'] = reqs_noextra
+    res.reqs_by_extra[".none"] = reqs_noextra
 
     return res
+
 
 def _expand_requires_extra(re):
     for extra, reqs in sorted(re.items()):
         for req in reqs:
-            if ';' in req:
-                name, envmark = req.split(';', 1)
+            if ";" in req:
+                name, envmark = req.split(";", 1)
                 yield '{} ; extra == "{}" and ({})'.format(name, extra, envmark)
             else:
                 yield '{} ; extra == "{}"'.format(req, extra)
@@ -419,49 +444,49 @@ def _check_type(d, field_name, cls):
             "{} field should be {}, not {}".format(field_name, cls, type(d[field_name]))
         )
 
+
 def _check_list_of_str(d, field_name):
     if not isinstance(d[field_name], list) or not all(
         isinstance(e, str) for e in d[field_name]
     ):
-        raise ConfigError(
-            "{} field should be a list of strings".format(field_name)
-        )
+        raise ConfigError("{} field should be a list of strings".format(field_name))
+
 
 def read_pep621_metadata(proj, path) -> LoadedConfig:
     lc = LoadedConfig()
     md_dict = lc.metadata
 
-    if 'name' not in proj:
-        raise ConfigError('name must be specified in [project] table')
-    _check_type(proj, 'name', str)
-    md_dict['name'] = proj['name']
-    lc.module = md_dict['name'].replace('-', '_')
+    if "name" not in proj:
+        raise ConfigError("name must be specified in [project] table")
+    _check_type(proj, "name", str)
+    md_dict["name"] = proj["name"]
+    lc.module = md_dict["name"].replace("-", "_")
 
     unexpected_keys = proj.keys() - pep621_allowed_fields
     if unexpected_keys:
-        log.warning("Unexpected names under [project]: %s", ', '.join(unexpected_keys))
+        log.warning("Unexpected names under [project]: %s", ", ".join(unexpected_keys))
 
-    if 'version' in proj:
-        _check_type(proj, 'version', str)
-        md_dict['version'] = normalise_version(proj['version'])
-    if 'description' in proj:
-        _check_type(proj, 'description', str)
-        md_dict['summary'] = proj['description']
-    if 'readme' in proj:
-        readme = proj['readme']
+    if "version" in proj:
+        _check_type(proj, "version", str)
+        md_dict["version"] = normalise_version(proj["version"])
+    if "description" in proj:
+        _check_type(proj, "description", str)
+        md_dict["summary"] = proj["description"]
+    if "readme" in proj:
+        readme = proj["readme"]
         if isinstance(readme, str):
             lc.referenced_files.append(readme)
             desc_content, mimetype = description_from_file(readme, path.parent)
 
         elif isinstance(readme, dict):
-            unrec_keys = set(readme.keys()) - {'text', 'file', 'content-type'}
+            unrec_keys = set(readme.keys()) - {"text", "file", "content-type"}
             if unrec_keys:
                 raise ConfigError(
                     "Unrecognised keys in [project.readme]: {}".format(unrec_keys)
                 )
-            if 'content-type' in readme:
-                mimetype = readme['content-type']
-                mtype_base = mimetype.split(';')[0].strip()  # e.g. text/x-rst
+            if "content-type" in readme:
+                mimetype = readme["content-type"]
+                mtype_base = mimetype.split(";")[0].strip()  # e.g. text/x-rst
                 if mtype_base not in readme_ext_to_content_type.values():
                     raise ConfigError(
                         "Unrecognised readme content-type: {!r}".format(mtype_base)
@@ -471,36 +496,34 @@ def read_pep621_metadata(proj, path) -> LoadedConfig:
                 raise ConfigError(
                     "content-type field required in [project.readme] table"
                 )
-            if 'file' in readme:
-                if 'text' in readme:
+            if "file" in readme:
+                if "text" in readme:
                     raise ConfigError(
                         "[project.readme] should specify file or text, not both"
                     )
-                lc.referenced_files.append(readme['file'])
+                lc.referenced_files.append(readme["file"])
                 desc_content, _ = description_from_file(
-                    readme['file'], path.parent, guess_mimetype=False
+                    readme["file"], path.parent, guess_mimetype=False
                 )
-            elif 'text' in readme:
-                desc_content = readme['text']
+            elif "text" in readme:
+                desc_content = readme["text"]
             else:
                 raise ConfigError(
                     "file or text field required in [project.readme] table"
                 )
         else:
-            raise ConfigError(
-                "project.readme should be a string or a table"
-            )
+            raise ConfigError("project.readme should be a string or a table")
 
-        md_dict['description'] = desc_content
-        md_dict['description_content_type'] = mimetype
+        md_dict["description"] = desc_content
+        md_dict["description_content_type"] = mimetype
 
-    if 'requires-python' in proj:
-        md_dict['requires_python'] = proj['requires-python']
+    if "requires-python" in proj:
+        md_dict["requires_python"] = proj["requires-python"]
 
-    if 'license' in proj:
-        _check_type(proj, 'license', dict)
-        license_tbl = proj['license']
-        unrec_keys = set(license_tbl.keys()) - {'text', 'file'}
+    if "license" in proj:
+        _check_type(proj, "license", dict)
+        license_tbl = proj["license"]
+        unrec_keys = set(license_tbl.keys()) - {"text", "file"}
         if unrec_keys:
             raise ConfigError(
                 "Unrecognised keys in [project.license]: {}".format(unrec_keys)
@@ -510,44 +533,42 @@ def read_pep621_metadata(proj, path) -> LoadedConfig:
         # The 'License' field in packaging metadata is a brief description of
         # a license, not the full text or a file path. PEP 639 will improve on
         # how licenses are recorded.
-        if 'file' in license_tbl:
-            if 'text' in license_tbl:
+        if "file" in license_tbl:
+            if "text" in license_tbl:
                 raise ConfigError(
                     "[project.license] should specify file or text, not both"
                 )
-            lc.referenced_files.append(license_tbl['file'])
-        elif 'text' in license_tbl:
+            lc.referenced_files.append(license_tbl["file"])
+        elif "text" in license_tbl:
             pass
         else:
-            raise ConfigError(
-                "file or text field required in [project.license] table"
-            )
+            raise ConfigError("file or text field required in [project.license] table")
 
-    if 'authors' in proj:
-        _check_type(proj, 'authors', list)
-        md_dict.update(pep621_people(proj['authors']))
+    if "authors" in proj:
+        _check_type(proj, "authors", list)
+        md_dict.update(pep621_people(proj["authors"]))
 
-    if 'maintainers' in proj:
-        _check_type(proj, 'maintainers', list)
-        md_dict.update(pep621_people(proj['maintainers'], group_name='maintainer'))
+    if "maintainers" in proj:
+        _check_type(proj, "maintainers", list)
+        md_dict.update(pep621_people(proj["maintainers"], group_name="maintainer"))
 
-    if 'keywords' in proj:
-        _check_list_of_str(proj, 'keywords')
-        md_dict['keywords'] = ",".join(proj['keywords'])
+    if "keywords" in proj:
+        _check_list_of_str(proj, "keywords")
+        md_dict["keywords"] = ",".join(proj["keywords"])
 
-    if 'classifiers' in proj:
-        _check_list_of_str(proj, 'classifiers')
-        md_dict['classifiers'] = proj['classifiers']
+    if "classifiers" in proj:
+        _check_list_of_str(proj, "classifiers")
+        md_dict["classifiers"] = proj["classifiers"]
 
-    if 'urls' in proj:
-        _check_type(proj, 'urls', dict)
-        project_urls = md_dict['project_urls'] = []
-        for label, url in sorted(proj['urls'].items()):
+    if "urls" in proj:
+        _check_type(proj, "urls", dict)
+        project_urls = md_dict["project_urls"] = []
+        for label, url in sorted(proj["urls"].items()):
             project_urls.append("{}, {}".format(label, url))
 
-    if 'entry-points' in proj:
-        _check_type(proj, 'entry-points', dict)
-        for grp in proj['entry-points'].values():
+    if "entry-points" in proj:
+        _check_type(proj, "entry-points", dict)
+        for grp in proj["entry-points"].values():
             if not isinstance(grp, dict):
                 raise ConfigError(
                     "projects.entry-points should only contain sub-tables"
@@ -556,62 +577,57 @@ def read_pep621_metadata(proj, path) -> LoadedConfig:
                 raise ConfigError(
                     "[projects.entry-points.*] tables should have string values"
                 )
-        if set(proj['entry-points'].keys()) & {'console_scripts', 'gui_scripts'}:
+        if set(proj["entry-points"].keys()) & {"console_scripts", "gui_scripts"}:
             raise ConfigError(
                 "Scripts should be specified in [project.scripts] or "
                 "[project.gui-scripts], not under [project.entry-points]"
             )
-        lc.entrypoints = proj['entry-points']
+        lc.entrypoints = proj["entry-points"]
 
-    if 'scripts' in proj:
-        _check_type(proj, 'scripts', dict)
-        if not all(isinstance(k, str) for k in proj['scripts'].values()):
-            raise ConfigError(
-                "[projects.scripts] table should have string values"
-            )
-        lc.entrypoints['console_scripts'] = proj['scripts']
+    if "scripts" in proj:
+        _check_type(proj, "scripts", dict)
+        if not all(isinstance(k, str) for k in proj["scripts"].values()):
+            raise ConfigError("[projects.scripts] table should have string values")
+        lc.entrypoints["console_scripts"] = proj["scripts"]
 
-    if 'gui-scripts' in proj:
-        _check_type(proj, 'gui-scripts', dict)
-        if not all(isinstance(k, str) for k in proj['gui-scripts'].values()):
-            raise ConfigError(
-                "[projects.gui-scripts] table should have string values"
-            )
-        lc.entrypoints['gui_scripts'] = proj['gui-scripts']
+    if "gui-scripts" in proj:
+        _check_type(proj, "gui-scripts", dict)
+        if not all(isinstance(k, str) for k in proj["gui-scripts"].values()):
+            raise ConfigError("[projects.gui-scripts] table should have string values")
+        lc.entrypoints["gui_scripts"] = proj["gui-scripts"]
 
-    if 'dependencies' in proj:
-        _check_list_of_str(proj, 'dependencies')
-        reqs_noextra = proj['dependencies']
+    if "dependencies" in proj:
+        _check_list_of_str(proj, "dependencies")
+        reqs_noextra = proj["dependencies"]
     else:
         reqs_noextra = []
 
-    if 'optional-dependencies' in proj:
-        _check_type(proj, 'optional-dependencies', dict)
-        optdeps = proj['optional-dependencies']
+    if "optional-dependencies" in proj:
+        _check_type(proj, "optional-dependencies", dict)
+        optdeps = proj["optional-dependencies"]
         if not all(isinstance(e, list) for e in optdeps.values()):
-            raise ConfigError(
-                'Expected a dict of lists in optional-dependencies field'
-            )
+            raise ConfigError("Expected a dict of lists in optional-dependencies field")
         for e, reqs in optdeps.items():
             if not all(isinstance(a, str) for a in reqs):
                 raise ConfigError(
-                    'Expected a string list for optional-dependencies ({})'.format(e)
+                    "Expected a string list for optional-dependencies ({})".format(e)
                 )
 
         lc.reqs_by_extra = optdeps.copy()
-        md_dict['provides_extra'] = sorted(lc.reqs_by_extra.keys())
+        md_dict["provides_extra"] = sorted(lc.reqs_by_extra.keys())
 
-    md_dict['requires_dist'] = \
-        reqs_noextra + list(_expand_requires_extra(lc.reqs_by_extra))
+    md_dict["requires_dist"] = reqs_noextra + list(
+        _expand_requires_extra(lc.reqs_by_extra)
+    )
 
     # For internal use, record the main requirements as a '.none' extra.
     if reqs_noextra:
-        lc.reqs_by_extra['.none'] = reqs_noextra
+        lc.reqs_by_extra[".none"] = reqs_noextra
 
-    if 'dynamic' in proj:
-        _check_list_of_str(proj, 'dynamic')
-        dynamic = set(proj['dynamic'])
-        unrec_dynamic = dynamic - {'version', 'description'}
+    if "dynamic" in proj:
+        _check_list_of_str(proj, "dynamic")
+        dynamic = set(proj["dynamic"])
+        unrec_dynamic = dynamic - {"version", "description"}
         if unrec_dynamic:
             raise ConfigError(
                 "flit only supports dynamic metadata for 'version' & 'description'"
@@ -622,39 +638,40 @@ def read_pep621_metadata(proj, path) -> LoadedConfig:
             )
         lc.dynamic_metadata = dynamic
 
-    if ('version' not in proj) and ('version' not in lc.dynamic_metadata):
+    if ("version" not in proj) and ("version" not in lc.dynamic_metadata):
         raise ConfigError(
             "version must be specified under [project] or listed as a dynamic field"
         )
-    if ('description' not in proj) and ('description' not in lc.dynamic_metadata):
+    if ("description" not in proj) and ("description" not in lc.dynamic_metadata):
         raise ConfigError(
             "description must be specified under [project] or listed as a dynamic field"
         )
 
     return lc
 
-def pep621_people(people, group_name='author') -> dict:
+
+def pep621_people(people, group_name="author") -> dict:
     """Convert authors/maintainers from PEP 621 to core metadata fields"""
     names, emails = [], []
     for person in people:
         if not isinstance(person, dict):
             raise ConfigError("{} info must be list of dicts".format(group_name))
-        unrec_keys = set(person.keys()) - {'name', 'email'}
+        unrec_keys = set(person.keys()) - {"name", "email"}
         if unrec_keys:
             raise ConfigError(
                 "Unrecognised keys in {} info: {}".format(group_name, unrec_keys)
             )
-        if 'email' in person:
-            email = person['email']
-            if 'name' in person:
-                email = str(Address(person['name'], addr_spec=email))
+        if "email" in person:
+            email = person["email"]
+            if "name" in person:
+                email = str(Address(person["name"], addr_spec=email))
             emails.append(email)
-        elif 'name' in person:
-            names.append(person['name'])
+        elif "name" in person:
+            names.append(person["name"])
 
     res = {}
     if names:
         res[group_name] = ", ".join(names)
     if emails:
-        res[group_name + '_email'] = ", ".join(emails)
+        res[group_name + "_email"] = ", ".join(emails)
     return res

--- a/test/pyproject.toml
+++ b/test/pyproject.toml
@@ -1,0 +1,46 @@
+[build-system]
+requires = ["flit_core >=3.8.0,<4"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "flit"
+authors = [
+    {name = "Thomas Kluyver", email = "thomas@kluyver.me.uk"},
+]
+dependencies = [
+    "flit_core >=3.8.0",
+    "requests",
+    "docutils",
+    "tomli-w",
+]
+requires-python = ">=3.6"
+readme = "README.rst"
+license = {file = "LICENSE"}
+classifiers = ["Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Programming Language :: Python :: 3",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dynamic = ['version', 'description']
+
+[project.optional-dependencies]
+test = [
+	"testpath",
+	"responses",
+	"pytest>=2.7.3",
+	"pytest-cov",
+	"tomli",
+]
+doc = [
+	"sphinx",
+	"sphinxcontrib_github_alt",
+	"pygments-github-lexers",  # TOML highlighting
+]
+
+[project.urls]
+Documentation = "https://flit.pypa.io"
+Source = "https://github.com/pypa/flit"
+Changelog = "https://flit.pypa.io/en/stable/history.html"
+
+[project.scripts]
+flit = "flit:main"

--- a/tests/samples/only-deps.toml
+++ b/tests/samples/only-deps.toml
@@ -1,0 +1,10 @@
+[build-system]
+requires = ["flit"]
+
+[tool.flit.metadata]
+module = "nomodule"
+author = "Sir Robin"
+author-email = "robin@camelot.uk"
+home-page = "http://github.com/sirrobin/module1"
+description-file = "NO_README.rst"
+requires = ["requests"]

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -8,26 +8,33 @@ from unittest.mock import patch
 
 import pytest
 from testpath import (
-    assert_isfile, assert_isdir, assert_islink, assert_not_path_exists, MockCommand
+    assert_isfile,
+    assert_isdir,
+    assert_islink,
+    assert_not_path_exists,
+    MockCommand,
 )
 
 from flit import install
 from flit.install import Installer, _requires_dist_to_pip_requirement, DependencyError
 import flit_core.tests
 
-samples_dir = pathlib.Path(__file__).parent / 'samples'
-core_samples_dir = pathlib.Path(flit_core.tests.__file__).parent / 'samples'
+samples_dir = pathlib.Path(__file__).parent / "samples"
+core_samples_dir = pathlib.Path(flit_core.tests.__file__).parent / "samples"
+
 
 class InstallTests(TestCase):
     def setUp(self):
         td = tempfile.TemporaryDirectory()
         self.addCleanup(td.cleanup)
-        self.get_dirs_patch = patch('flit.install.get_dirs',
-                return_value={
-                    'scripts': os.path.join(td.name, 'scripts'),
-                    'purelib': os.path.join(td.name, 'site-packages'),
-                    'data': os.path.join(td.name, 'data'),
-                })
+        self.get_dirs_patch = patch(
+            "flit.install.get_dirs",
+            return_value={
+                "scripts": os.path.join(td.name, "scripts"),
+                "purelib": os.path.join(td.name, "site-packages"),
+                "data": os.path.join(td.name, "data"),
+            },
+        )
         self.get_dirs_patch.start()
         self.tmpdir = pathlib.Path(td.name)
 
@@ -37,251 +44,309 @@ class InstallTests(TestCase):
     def _assert_direct_url(self, directory, package, version, expected_editable):
         direct_url_file = (
             self.tmpdir
-            / 'site-packages'
-            / '{}-{}.dist-info'.format(package, version)
-            / 'direct_url.json'
+            / "site-packages"
+            / "{}-{}.dist-info".format(package, version)
+            / "direct_url.json"
         )
         assert_isfile(direct_url_file)
         with direct_url_file.open() as f:
             direct_url = json.load(f)
-            assert direct_url['url'].startswith('file:///')
-            assert direct_url['url'] == directory.as_uri()
-            assert direct_url['dir_info'].get('editable') is expected_editable
+            assert direct_url["url"].startswith("file:///")
+            assert direct_url["url"] == directory.as_uri()
+            assert direct_url["dir_info"].get("editable") is expected_editable
 
     def test_install_module(self):
-        Installer.from_ini_path(samples_dir / 'module1_toml' / 'pyproject.toml').install_directly()
-        assert_isfile(self.tmpdir / 'site-packages' / 'module1.py')
-        assert_isdir(self.tmpdir / 'site-packages' / 'module1-0.1.dist-info')
+        Installer.from_ini_path(
+            samples_dir / "module1_toml" / "pyproject.toml"
+        ).install_directly()
+        assert_isfile(self.tmpdir / "site-packages" / "module1.py")
+        assert_isdir(self.tmpdir / "site-packages" / "module1-0.1.dist-info")
         self._assert_direct_url(
-            samples_dir / 'module1_toml', 'module1', '0.1', expected_editable=False
+            samples_dir / "module1_toml", "module1", "0.1", expected_editable=False
         )
 
     def test_install_module_pep621(self):
         Installer.from_ini_path(
-            core_samples_dir / 'pep621_nodynamic' / 'pyproject.toml',
+            core_samples_dir / "pep621_nodynamic" / "pyproject.toml",
         ).install_directly()
-        assert_isfile(self.tmpdir / 'site-packages' / 'module1.py')
-        assert_isdir(self.tmpdir / 'site-packages' / 'module1-0.3.dist-info')
+        assert_isfile(self.tmpdir / "site-packages" / "module1.py")
+        assert_isdir(self.tmpdir / "site-packages" / "module1-0.3.dist-info")
         self._assert_direct_url(
-            core_samples_dir / 'pep621_nodynamic', 'module1', '0.3',
-            expected_editable=False
+            core_samples_dir / "pep621_nodynamic",
+            "module1",
+            "0.3",
+            expected_editable=False,
         )
 
     def test_install_package(self):
         oldcwd = os.getcwd()
-        os.chdir(str(samples_dir / 'package1'))
+        os.chdir(str(samples_dir / "package1"))
         try:
-            Installer.from_ini_path(pathlib.Path('pyproject.toml')).install_directly()
+            Installer.from_ini_path(pathlib.Path("pyproject.toml")).install_directly()
         finally:
             os.chdir(oldcwd)
-        assert_isdir(self.tmpdir / 'site-packages' / 'package1')
-        assert_isdir(self.tmpdir / 'site-packages' / 'package1-0.1.dist-info')
-        assert_isfile(self.tmpdir / 'scripts' / 'pkg_script')
-        with (self.tmpdir / 'scripts' / 'pkg_script').open() as f:
+        assert_isdir(self.tmpdir / "site-packages" / "package1")
+        assert_isdir(self.tmpdir / "site-packages" / "package1-0.1.dist-info")
+        assert_isfile(self.tmpdir / "scripts" / "pkg_script")
+        with (self.tmpdir / "scripts" / "pkg_script").open() as f:
             assert f.readline().strip() == "#!" + sys.executable
         self._assert_direct_url(
-            samples_dir / 'package1', 'package1', '0.1', expected_editable=False
+            samples_dir / "package1", "package1", "0.1", expected_editable=False
         )
 
     def test_install_module_in_src(self):
         oldcwd = os.getcwd()
-        os.chdir(samples_dir / 'packageinsrc')
+        os.chdir(samples_dir / "packageinsrc")
         try:
-            Installer.from_ini_path(pathlib.Path('pyproject.toml')).install_directly()
+            Installer.from_ini_path(pathlib.Path("pyproject.toml")).install_directly()
         finally:
             os.chdir(oldcwd)
-        assert_isfile(self.tmpdir / 'site-packages' / 'module1.py')
-        assert_isdir(self.tmpdir / 'site-packages' / 'module1-0.1.dist-info')
+        assert_isfile(self.tmpdir / "site-packages" / "module1.py")
+        assert_isdir(self.tmpdir / "site-packages" / "module1-0.1.dist-info")
 
     def test_install_ns_package_native(self):
-        Installer.from_ini_path(samples_dir / 'ns1-pkg' / 'pyproject.toml').install_directly()
-        assert_isdir(self.tmpdir / 'site-packages' / 'ns1')
-        assert_isfile(self.tmpdir / 'site-packages' / 'ns1' / 'pkg' / '__init__.py')
-        assert_not_path_exists(self.tmpdir / 'site-packages' / 'ns1' / '__init__.py')
-        assert_isdir(self.tmpdir / 'site-packages' / 'ns1_pkg-0.1.dist-info')
+        Installer.from_ini_path(
+            samples_dir / "ns1-pkg" / "pyproject.toml"
+        ).install_directly()
+        assert_isdir(self.tmpdir / "site-packages" / "ns1")
+        assert_isfile(self.tmpdir / "site-packages" / "ns1" / "pkg" / "__init__.py")
+        assert_not_path_exists(self.tmpdir / "site-packages" / "ns1" / "__init__.py")
+        assert_isdir(self.tmpdir / "site-packages" / "ns1_pkg-0.1.dist-info")
 
     def test_install_ns_package_module_native(self):
-        Installer.from_ini_path(samples_dir / 'ns1-pkg-mod' / 'pyproject.toml').install_directly()
-        assert_isfile(self.tmpdir / 'site-packages' / 'ns1' / 'module.py')
-        assert_not_path_exists(self.tmpdir / 'site-packages' / 'ns1' / '__init__.py')
+        Installer.from_ini_path(
+            samples_dir / "ns1-pkg-mod" / "pyproject.toml"
+        ).install_directly()
+        assert_isfile(self.tmpdir / "site-packages" / "ns1" / "module.py")
+        assert_not_path_exists(self.tmpdir / "site-packages" / "ns1" / "__init__.py")
 
     def test_install_ns_package_native_symlink(self):
-        if os.name == 'nt':
-            raise SkipTest('symlink')
+        if os.name == "nt":
+            raise SkipTest("symlink")
         Installer.from_ini_path(
-            samples_dir / 'ns1-pkg' / 'pyproject.toml', symlink=True
+            samples_dir / "ns1-pkg" / "pyproject.toml", symlink=True
         ).install_directly()
         Installer.from_ini_path(
-            samples_dir / 'ns1-pkg2' / 'pyproject.toml', symlink=True
+            samples_dir / "ns1-pkg2" / "pyproject.toml", symlink=True
         ).install_directly()
         Installer.from_ini_path(
-            samples_dir / 'ns1-pkg-mod' / 'pyproject.toml', symlink=True
+            samples_dir / "ns1-pkg-mod" / "pyproject.toml", symlink=True
         ).install_directly()
-        assert_isdir(self.tmpdir / 'site-packages' / 'ns1')
-        assert_isdir(self.tmpdir / 'site-packages' / 'ns1' / 'pkg')
-        assert_islink(self.tmpdir / 'site-packages' / 'ns1' / 'pkg',
-                      to=str(samples_dir / 'ns1-pkg' / 'ns1' / 'pkg'))
-        assert_isdir(self.tmpdir / 'site-packages' / 'ns1_pkg-0.1.dist-info')
+        assert_isdir(self.tmpdir / "site-packages" / "ns1")
+        assert_isdir(self.tmpdir / "site-packages" / "ns1" / "pkg")
+        assert_islink(
+            self.tmpdir / "site-packages" / "ns1" / "pkg",
+            to=str(samples_dir / "ns1-pkg" / "ns1" / "pkg"),
+        )
+        assert_isdir(self.tmpdir / "site-packages" / "ns1_pkg-0.1.dist-info")
 
-        assert_isdir(self.tmpdir / 'site-packages' / 'ns1' / 'pkg2')
-        assert_islink(self.tmpdir / 'site-packages' / 'ns1' / 'pkg2',
-                      to=str(samples_dir / 'ns1-pkg2' / 'ns1' / 'pkg2'))
-        assert_isdir(self.tmpdir / 'site-packages' / 'ns1_pkg2-0.1.dist-info')
+        assert_isdir(self.tmpdir / "site-packages" / "ns1" / "pkg2")
+        assert_islink(
+            self.tmpdir / "site-packages" / "ns1" / "pkg2",
+            to=str(samples_dir / "ns1-pkg2" / "ns1" / "pkg2"),
+        )
+        assert_isdir(self.tmpdir / "site-packages" / "ns1_pkg2-0.1.dist-info")
 
-        assert_islink(self.tmpdir / 'site-packages' / 'ns1' / 'module.py',
-                      to=samples_dir / 'ns1-pkg-mod' / 'ns1' / 'module.py')
-        assert_isdir(self.tmpdir / 'site-packages' / 'ns1_module-0.1.dist-info')
+        assert_islink(
+            self.tmpdir / "site-packages" / "ns1" / "module.py",
+            to=samples_dir / "ns1-pkg-mod" / "ns1" / "module.py",
+        )
+        assert_isdir(self.tmpdir / "site-packages" / "ns1_module-0.1.dist-info")
 
     def test_install_ns_package_pth_file(self):
         Installer.from_ini_path(
-            samples_dir / 'ns1-pkg' / 'pyproject.toml', pth=True
+            samples_dir / "ns1-pkg" / "pyproject.toml", pth=True
         ).install_directly()
 
-        pth_file = self.tmpdir / 'site-packages' / 'ns1.pkg.pth'
+        pth_file = self.tmpdir / "site-packages" / "ns1.pkg.pth"
         assert_isfile(pth_file)
-        assert pth_file.read_text('utf-8').strip() == str(samples_dir / 'ns1-pkg')
+        assert pth_file.read_text("utf-8").strip() == str(samples_dir / "ns1-pkg")
 
     def test_symlink_package(self):
-        if os.name == 'nt':
+        if os.name == "nt":
             raise SkipTest("symlink")
-        Installer.from_ini_path(samples_dir / 'package1' / 'pyproject.toml', symlink=True).install()
-        assert_islink(self.tmpdir / 'site-packages' / 'package1',
-                      to=samples_dir / 'package1' / 'package1')
-        assert_isfile(self.tmpdir / 'scripts' / 'pkg_script')
-        with (self.tmpdir / 'scripts' / 'pkg_script').open() as f:
+        Installer.from_ini_path(
+            samples_dir / "package1" / "pyproject.toml", symlink=True
+        ).install()
+        assert_islink(
+            self.tmpdir / "site-packages" / "package1",
+            to=samples_dir / "package1" / "package1",
+        )
+        assert_isfile(self.tmpdir / "scripts" / "pkg_script")
+        with (self.tmpdir / "scripts" / "pkg_script").open() as f:
             assert f.readline().strip() == "#!" + sys.executable
         self._assert_direct_url(
-            samples_dir / 'package1', 'package1', '0.1', expected_editable=True
+            samples_dir / "package1", "package1", "0.1", expected_editable=True
         )
 
     def test_symlink_module_pep621(self):
-        if os.name == 'nt':
+        if os.name == "nt":
             raise SkipTest("symlink")
         Installer.from_ini_path(
-            core_samples_dir / 'pep621_nodynamic' / 'pyproject.toml', symlink=True
+            core_samples_dir / "pep621_nodynamic" / "pyproject.toml", symlink=True
         ).install_directly()
-        assert_islink(self.tmpdir / 'site-packages' / 'module1.py',
-                      to=core_samples_dir / 'pep621_nodynamic' / 'module1.py')
-        assert_isdir(self.tmpdir / 'site-packages' / 'module1-0.3.dist-info')
+        assert_islink(
+            self.tmpdir / "site-packages" / "module1.py",
+            to=core_samples_dir / "pep621_nodynamic" / "module1.py",
+        )
+        assert_isdir(self.tmpdir / "site-packages" / "module1-0.3.dist-info")
         self._assert_direct_url(
-            core_samples_dir / 'pep621_nodynamic', 'module1', '0.3',
-            expected_editable=True
+            core_samples_dir / "pep621_nodynamic",
+            "module1",
+            "0.3",
+            expected_editable=True,
         )
 
     def test_symlink_module_in_src(self):
-        if os.name == 'nt':
+        if os.name == "nt":
             raise SkipTest("symlink")
         oldcwd = os.getcwd()
-        os.chdir(samples_dir / 'packageinsrc')
+        os.chdir(samples_dir / "packageinsrc")
         try:
             Installer.from_ini_path(
-                pathlib.Path('pyproject.toml'), symlink=True
+                pathlib.Path("pyproject.toml"), symlink=True
             ).install_directly()
         finally:
             os.chdir(oldcwd)
-        assert_islink(self.tmpdir / 'site-packages' / 'module1.py',
-                      to=(samples_dir / 'packageinsrc' / 'src' / 'module1.py'))
-        assert_isdir(self.tmpdir / 'site-packages' / 'module1-0.1.dist-info')
+        assert_islink(
+            self.tmpdir / "site-packages" / "module1.py",
+            to=(samples_dir / "packageinsrc" / "src" / "module1.py"),
+        )
+        assert_isdir(self.tmpdir / "site-packages" / "module1-0.1.dist-info")
 
     def test_pth_package(self):
-        Installer.from_ini_path(samples_dir / 'package1' / 'pyproject.toml', pth=True).install()
-        assert_isfile(self.tmpdir / 'site-packages' / 'package1.pth')
-        with open(str(self.tmpdir / 'site-packages' / 'package1.pth')) as f:
-            assert f.read() == str(samples_dir / 'package1')
-        assert_isfile(self.tmpdir / 'scripts' / 'pkg_script')
+        Installer.from_ini_path(
+            samples_dir / "package1" / "pyproject.toml", pth=True
+        ).install()
+        assert_isfile(self.tmpdir / "site-packages" / "package1.pth")
+        with open(str(self.tmpdir / "site-packages" / "package1.pth")) as f:
+            assert f.read() == str(samples_dir / "package1")
+        assert_isfile(self.tmpdir / "scripts" / "pkg_script")
         self._assert_direct_url(
-            samples_dir / 'package1', 'package1', '0.1', expected_editable=True
+            samples_dir / "package1", "package1", "0.1", expected_editable=True
         )
 
     def test_pth_module_in_src(self):
         oldcwd = os.getcwd()
-        os.chdir(samples_dir / 'packageinsrc')
+        os.chdir(samples_dir / "packageinsrc")
         try:
             Installer.from_ini_path(
-                pathlib.Path('pyproject.toml'), pth=True
+                pathlib.Path("pyproject.toml"), pth=True
             ).install_directly()
         finally:
             os.chdir(oldcwd)
-        pth_path = self.tmpdir / 'site-packages' / 'module1.pth'
+        pth_path = self.tmpdir / "site-packages" / "module1.pth"
         assert_isfile(pth_path)
-        assert pth_path.read_text('utf-8').strip() == str(
-            samples_dir / 'packageinsrc' / 'src'
+        assert pth_path.read_text("utf-8").strip() == str(
+            samples_dir / "packageinsrc" / "src"
         )
-        assert_isdir(self.tmpdir / 'site-packages' / 'module1-0.1.dist-info')
+        assert_isdir(self.tmpdir / "site-packages" / "module1-0.1.dist-info")
 
     def test_dist_name(self):
-        Installer.from_ini_path(samples_dir / 'altdistname' / 'pyproject.toml').install_directly()
-        assert_isdir(self.tmpdir / 'site-packages' / 'package1')
-        assert_isdir(self.tmpdir / 'site-packages' / 'package_dist1-0.1.dist-info')
+        Installer.from_ini_path(
+            samples_dir / "altdistname" / "pyproject.toml"
+        ).install_directly()
+        assert_isdir(self.tmpdir / "site-packages" / "package1")
+        assert_isdir(self.tmpdir / "site-packages" / "package_dist1-0.1.dist-info")
 
     def test_entry_points(self):
-        Installer.from_ini_path(samples_dir / 'entrypoints_valid' / 'pyproject.toml').install_directly()
-        assert_isfile(self.tmpdir / 'site-packages' / 'package1-0.1.dist-info' / 'entry_points.txt')
+        Installer.from_ini_path(
+            samples_dir / "entrypoints_valid" / "pyproject.toml"
+        ).install_directly()
+        assert_isfile(
+            self.tmpdir
+            / "site-packages"
+            / "package1-0.1.dist-info"
+            / "entry_points.txt"
+        )
 
     def test_pip_install(self):
-        ins = Installer.from_ini_path(samples_dir / 'package1' / 'pyproject.toml', python='mock_python',
-                        user=False)
+        ins = Installer.from_ini_path(
+            samples_dir / "package1" / "pyproject.toml",
+            python="mock_python",
+            user=False,
+        )
 
-        with MockCommand('mock_python') as mock_py:
+        with MockCommand("mock_python") as mock_py:
             ins.install()
 
         calls = mock_py.get_calls()
         assert len(calls) == 1
-        cmd = calls[0]['argv']
-        assert cmd[1:4] == ['-m', 'pip', 'install']
-        assert cmd[4].endswith('package1')
+        cmd = calls[0]["argv"]
+        assert cmd[1:4] == ["-m", "pip", "install"]
+        assert cmd[4].endswith("package1")
 
     def test_symlink_other_python(self):
-        if os.name == 'nt':
-            raise SkipTest('symlink')
-        (self.tmpdir / 'site-packages2').mkdir()
-        (self.tmpdir / 'scripts2').mkdir()
+        if os.name == "nt":
+            raise SkipTest("symlink")
+        (self.tmpdir / "site-packages2").mkdir()
+        (self.tmpdir / "scripts2").mkdir()
 
         # Called by Installer._auto_user() :
-        script1 = ("#!{python}\n"
-                   "import sysconfig\n"
-                   "print(True)\n"   # site.ENABLE_USER_SITE
-                   "print({purelib!r})"  # sysconfig.get_path('purelib')
-                  ).format(python=sys.executable,
-                           purelib=str(self.tmpdir / 'site-packages2'))
+        script1 = (
+            "#!{python}\n"
+            "import sysconfig\n"
+            "print(True)\n"  # site.ENABLE_USER_SITE
+            "print({purelib!r})"  # sysconfig.get_path('purelib')
+        ).format(python=sys.executable, purelib=str(self.tmpdir / "site-packages2"))
 
         # Called by Installer._get_dirs() :
-        script2 = ("#!{python}\n"
-                   "import json, sys\n"
-                   "json.dump({{'purelib': {purelib!r}, 'scripts': {scripts!r}, 'data': {data!r} }}, "
-                   "sys.stdout)"
-                  ).format(python=sys.executable,
-                           purelib=str(self.tmpdir / 'site-packages2'),
-                           scripts=str(self.tmpdir / 'scripts2'),
-                           data=str(self.tmpdir / 'data'),
-                  )
+        script2 = (
+            "#!{python}\n"
+            "import json, sys\n"
+            "json.dump({{'purelib': {purelib!r}, 'scripts': {scripts!r}, 'data': {data!r} }}, "
+            "sys.stdout)"
+        ).format(
+            python=sys.executable,
+            purelib=str(self.tmpdir / "site-packages2"),
+            scripts=str(self.tmpdir / "scripts2"),
+            data=str(self.tmpdir / "data"),
+        )
 
-        with MockCommand('mock_python', content=script1):
-            ins = Installer.from_ini_path(samples_dir / 'package1' / 'pyproject.toml', python='mock_python',
-                      symlink=True)
-        with MockCommand('mock_python', content=script2):
+        with MockCommand("mock_python", content=script1):
+            ins = Installer.from_ini_path(
+                samples_dir / "package1" / "pyproject.toml",
+                python="mock_python",
+                symlink=True,
+            )
+        with MockCommand("mock_python", content=script2):
             ins.install()
 
-        assert_islink(self.tmpdir / 'site-packages2' / 'package1',
-                      to=samples_dir / 'package1' / 'package1')
-        assert_isfile(self.tmpdir / 'scripts2' / 'pkg_script')
-        with (self.tmpdir / 'scripts2' / 'pkg_script').open() as f:
+        assert_islink(
+            self.tmpdir / "site-packages2" / "package1",
+            to=samples_dir / "package1" / "package1",
+        )
+        assert_isfile(self.tmpdir / "scripts2" / "pkg_script")
+        with (self.tmpdir / "scripts2" / "pkg_script").open() as f:
             assert f.readline().strip() == "#!mock_python"
 
     def test_install_requires(self):
-        ins = Installer.from_ini_path(samples_dir / 'requires-requests.toml',
-                        user=False, python='mock_python')
+        ins = Installer.from_ini_path(
+            samples_dir / "requires-requests.toml", user=False, python="mock_python"
+        )
 
-        with MockCommand('mock_python') as mockpy:
+        with MockCommand("mock_python") as mockpy:
             ins.install_requirements()
         calls = mockpy.get_calls()
         assert len(calls) == 1
-        assert calls[0]['argv'][1:5] == ['-m', 'pip', 'install', '-r']
+        assert calls[0]["argv"][1:5] == ["-m", "pip", "install", "-r"]
+
+    def test_install_only_deps(self):
+        os.environ.setdefault("FLIT_ALLOW_INVALID", "1")
+        ins = Installer.from_ini_path(
+            samples_dir / "only-deps.toml", user=False, python="mock_python"
+        )
+
+        with MockCommand("mock_python") as mockpy:
+            ins.install_requirements()
+        calls = mockpy.get_calls()
+        assert len(calls) == 1
+        assert calls[0]["argv"][1:5] == ["-m", "pip", "install", "-r"]
 
     def test_install_reqs_my_python_if_needed_pep621(self):
         ins = Installer.from_ini_path(
-            core_samples_dir / 'pep621_nodynamic' / 'pyproject.toml',
-            deps='none',
+            core_samples_dir / "pep621_nodynamic" / "pyproject.toml",
+            deps="none",
         )
 
         # This shouldn't try to get version & docstring from the module
@@ -289,42 +354,61 @@ class InstallTests(TestCase):
 
     def test_extras_error(self):
         with pytest.raises(DependencyError):
-            Installer.from_ini_path(samples_dir / 'requires-requests.toml',
-                            user=False, deps='none', extras='dev')
+            Installer.from_ini_path(
+                samples_dir / "requires-requests.toml",
+                user=False,
+                deps="none",
+                extras="dev",
+            )
 
     def test_install_data_dir(self):
         Installer.from_ini_path(
-            core_samples_dir / 'with_data_dir' / 'pyproject.toml',
+            core_samples_dir / "with_data_dir" / "pyproject.toml",
         ).install_directly()
-        assert_isfile(self.tmpdir / 'site-packages' / 'module1.py')
-        assert_isfile(self.tmpdir / 'data' / 'share' / 'man' / 'man1' / 'foo.1')
+        assert_isfile(self.tmpdir / "site-packages" / "module1.py")
+        assert_isfile(self.tmpdir / "data" / "share" / "man" / "man1" / "foo.1")
 
     def test_symlink_data_dir(self):
-        if os.name == 'nt':
+        if os.name == "nt":
             raise SkipTest("symlink")
         Installer.from_ini_path(
-            core_samples_dir / 'with_data_dir' / 'pyproject.toml', symlink=True
+            core_samples_dir / "with_data_dir" / "pyproject.toml", symlink=True
         ).install_directly()
-        assert_isfile(self.tmpdir / 'site-packages' / 'module1.py')
+        assert_isfile(self.tmpdir / "site-packages" / "module1.py")
         assert_islink(
-            self.tmpdir / 'data' / 'share' / 'man' / 'man1' / 'foo.1',
-            to=core_samples_dir / 'with_data_dir' / 'data' / 'share' / 'man' / 'man1' / 'foo.1'
+            self.tmpdir / "data" / "share" / "man" / "man1" / "foo.1",
+            to=core_samples_dir
+            / "with_data_dir"
+            / "data"
+            / "share"
+            / "man"
+            / "man1"
+            / "foo.1",
         )
 
-@pytest.mark.parametrize(('deps', 'extras', 'installed'), [
-    ('none', [], set()),
-    ('develop', [], {'pytest ;', 'toml ;'}),
-    ('production', [], {'toml ;'}),
-    ('all', [], {'toml ;', 'pytest ;', 'requests ;'}),
-])
+
+@pytest.mark.parametrize(
+    ("deps", "extras", "installed"),
+    [
+        ("none", [], set()),
+        ("develop", [], {"pytest ;", "toml ;"}),
+        ("production", [], {"toml ;"}),
+        ("all", [], {"toml ;", "pytest ;", "requests ;"}),
+    ],
+)
 def test_install_requires_extra(deps, extras, installed):
     it = InstallTests()
     try:
         it.setUp()
-        ins = Installer.from_ini_path(samples_dir / 'extras' / 'pyproject.toml', python='mock_python',
-                        user=False, deps=deps, extras=extras)
+        ins = Installer.from_ini_path(
+            samples_dir / "extras" / "pyproject.toml",
+            python="mock_python",
+            user=False,
+            deps=deps,
+            extras=extras,
+        )
 
-        cmd = MockCommand('mock_python')
+        cmd = MockCommand("mock_python")
         get_reqs = (
             "#!{python}\n"
             "import sys\n"
@@ -337,16 +421,20 @@ def test_install_requires_extra(deps, extras, installed):
             ins.install_requirements()
         with open(mock_py.recording_file) as f:
             str_deps = f.read()
-        deps = str_deps.split('\n') if str_deps else []
+        deps = str_deps.split("\n") if str_deps else []
 
         assert set(deps) == installed
     finally:
         it.tearDown()
 
+
 def test_requires_dist_to_pip_requirement():
     rd = 'pathlib2 (>=2.3); python_version == "2.7"'
-    assert _requires_dist_to_pip_requirement(rd) == \
-        'pathlib2>=2.3 ; python_version == "2.7"'
+    assert (
+        _requires_dist_to_pip_requirement(rd)
+        == 'pathlib2>=2.3 ; python_version == "2.7"'
+    )
+
 
 def test_test_writable_dir_win():
     with tempfile.TemporaryDirectory() as td:
@@ -354,7 +442,7 @@ def test_test_writable_dir_win():
 
         # Ironically, I don't know how to make a non-writable dir on Windows,
         # so although the functionality is for Windows, the test is for Posix
-        if os.name != 'posix':
+        if os.name != "posix":
             return
 
         # Remove write permissions from the directory


### PR DESCRIPTION
Currently, trying to run "flit install --only-deps" includes checks that require both the README and the module folder be present, even though they are not actually needed. When trying to use --only-deps in my docker file, I have to also copy the README and have to create a fake directory.

```Dockerfile
FROM mcr.microsoft.com/devcontainers/python:3

RUN python -m pip install --upgrade pip \
    && python -m pip install pytest pytest-cov \
    && python -m pip install 'flit>=3.8.0'

ENV FLIT_ROOT_INSTALL=1

COPY pyproject.toml README.rst ./
RUN mkdir -p flit \
    && python -m flit install --only-deps --deps develop \
    && rm -r pyproject.toml README.rst flit
```

flit already includes a flag to try and install if there are invalid settings, `FLIT_ALLOW_INVALID`. I have extended the use of that flag to enable running --only-deps without the checks. The updated Dockerfile is.

```Dockerfile
FROM mcr.microsoft.com/devcontainers/python:3

RUN python -m pip install --upgrade pip \
    && python -m pip install pytest pytest-cov \
    && python -m pip install 'flit>=3.8.1'

ENV FLIT_ROOT_INSTALL=1
ENV FLIT_ALLOW_INVALID=1

COPY pyproject.toml .
RUN python -m flit install --only-deps --deps develop \
    && rm -r pyproject.toml
```