### PR TITLE
Add devcontainer configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,12 @@
+FROM mcr.microsoft.com/devcontainers/python:3
+
+RUN python -m pip install --upgrade pip \
+    && python -m pip install pytest pytest-cov \
+    && python -m pip install 'flit>=3.8.0'
+
+ENV FLIT_ROOT_INSTALL=1
+
+COPY pyproject.toml README.rst ./
+RUN mkdir -p flit \
+    && python -m flit install --only-deps --deps develop \
+    && rm -r pyproject.toml README.rst flit


### PR DESCRIPTION
Adding a devcontainer configuration which can be used with GitHub Codespace or with VSCode to create a local container.

The configuration includes the basics configurations for Python.