### PR TITLE
Use fixed default for gzip timestamp in sdists

### DIFF
--- a/flit_core/flit_core/sdist.py
+++ b/flit_core/flit_core/sdist.py
@@ -166,7 +166,10 @@ class SdistBuilder:
         )
         source_date_epoch = os.environ.get('SOURCE_DATE_EPOCH', '')
         mtime = int(source_date_epoch) if source_date_epoch else None
-        gz = GzipFile(str(target), mode='wb', mtime=mtime)
+        # For the gzip timestamp, default to 2016-1-1 00:00 (UTC)
+        # This makes the sdist reproducible even without SOURCE_DATE_EPOCH,
+        # if the source file mtimes don't change, i.e. from the same checkout.
+        gz = GzipFile(str(target), mode='wb', mtime=(mtime or 1451606400))
         tf = tarfile.TarFile(str(target), mode='w', fileobj=gz,
                              format=tarfile.PAX_FORMAT)
 


### PR DESCRIPTION
This allows Flit to create byte-for-byte identical sdists even without `SOURCE_DATE_EPOCH` set, if run on the same checkout of the source files on the same machine.

Where timestamps relate to a file we're packing from the filesystem, we use that file's mtime, unless SOURCE_DATE_EPOCH overrides it. But other timestamps, including this one in the gzip format, automatically use the current time and thus aren't reproducible. We already set a fixed default timestamp for generated files added to wheels, for the same reason:

https://github.com/pypa/flit/blob/532bdaabafe0660b6c7494d8043ec4fa15b286a8/flit_core/flit_core/wheel.py#L145-L149

This doesn't matter for 'proper' reproducible builds, since to do that you'd set SOURCE_DATE_EPOCH anyway. But being readily able to generate identical distribution files within one system is a nice way to see that reproducibility is working. I think that's worth losing the small bit of extra metadata in that timestamp, which in practice is mostly redundant anyway (e.g. PyPI has timestamps for when files were uploaded).