### PR TITLE
deps: Add missing runtime dependency on pip

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,7 @@ dependencies = [
     "requests",
     "docutils",
     "tomli-w",
+    "pip",
 ]
 requires-python = ">=3.6"
 readme = "README.rst"


### PR DESCRIPTION
According to docs https://flit.pypa.io/en/stable/cmdline.html#flit-install:
> Flit calls pip to do the installation.

but pip was not specified as runtime dependency of flit.

Fixes: https://github.com/pypa/flit/issues/646