### PR TITLE
Support environments without pip

### DIFF
--- a/flit/install.py
+++ b/flit/install.py
@@ -249,8 +249,16 @@ class Installer(object):
             for req_d in requirements
         ]
 
+        # Use either pip in the venv or in the current environment,
+        # whichever is available.
+        try:
+            import pip  # noqa: F401
+        except ImportError:
+            cmd = [self.python, '-m', 'pip', 'install']
+        else:
+            cmd = [sys.executable, '-m', 'pip', 'install', '--python', self.python]
+
         # install the requirements with pip
-        cmd = [self.python, '-m', 'pip', 'install']
         if self.user:
             cmd.append('--user')
         with tempfile.NamedTemporaryFile(mode='w',


### PR DESCRIPTION
Before: use pip installed in the target environment.

After: If pip is available in the current environment, use it, pointing it to the target environment using the `--python` flag. Otherwise, if Python is not installed in the same environment as flit, fall back to the old behavior.

This change is [inspired by rye](https://github.com/mitsuhiko/rye/blob/d920f8428c58edbf4552a90a0b413bfe4c2336d8/rye/src/installer.rs#L103). It allows to use flit with virtual environments created with `--without-pip` flag.