### PR TITLE
Remove destination data files if they exist.

### DIFF
--- a/flit/install.py
+++ b/flit/install.py
@@ -201,8 +201,7 @@ class Installer(object):
             rel_path = os.path.relpath(src_path, self.ini_info.data_directory)
             dst_path = os.path.join(target_data_dir, rel_path)
             os.makedirs(os.path.dirname(dst_path), exist_ok=True)
-            if os.path.exists(dst_path):
-                os.remove(dst_path)
+            pathlib.Path(dst_path, missing_ok=True)
             if self.symlink:
                 os.symlink(os.path.realpath(src_path), dst_path)
             else:

--- a/flit/install.py
+++ b/flit/install.py
@@ -201,7 +201,7 @@ class Installer(object):
             rel_path = os.path.relpath(src_path, self.ini_info.data_directory)
             dst_path = os.path.join(target_data_dir, rel_path)
             os.makedirs(os.path.dirname(dst_path), exist_ok=True)
-            pathlib.Path(dst_path, missing_ok=True)
+            pathlib.Path(dst_path).unlink(missing_ok=True)
             if self.symlink:
                 os.symlink(os.path.realpath(src_path), dst_path)
             else:

--- a/flit/install.py
+++ b/flit/install.py
@@ -201,6 +201,8 @@ class Installer(object):
             rel_path = os.path.relpath(src_path, self.ini_info.data_directory)
             dst_path = os.path.join(target_data_dir, rel_path)
             os.makedirs(os.path.dirname(dst_path), exist_ok=True)
+            if os.path.exists(dst_path):
+                os.remove(dst_path)
             if self.symlink:
                 os.symlink(os.path.realpath(src_path), dst_path)
             else:


### PR DESCRIPTION
We recently switched to flit and I came across this issue when I installed a package using the "symlink" mode. What I did was adding more data files and then re installing the package to create the symlinks to the recently added data files:

```console
flit install -s
Traceback (most recent call last):
FileExistsError: [Errno 17] File exists: '/home/wilfred/workspace/deployment/assets/share/freva/deployment/config/create_tables.sql' -> '/tmp/py_311/share/freva/deployment/config/create_tables.sql'
```

Since without `-s` any existing data files would be overridden anyways I figured it's ok to delete any existing data files.