### PR TITLE
Require Python >=3.8 for flit CLI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "docutils",
     "tomli-w",
 ]
-requires-python = ">=3.6"
+requires-python = ">=3.8"
 readme = "README.rst"
 license = {file = "LICENSE"}
 classifiers = ["Intended Audience :: Developers",

--- a/tox.ini
+++ b/tox.ini
@@ -30,6 +30,16 @@ setenv =
 commands =
     python -m pytest --cov=flit --cov=flit_core/flit_core
 
+# Python 3.6: only test flit_core
+[testenv:py36]
+commands =
+    python -m pytest --cov=flit_core/flit_core --pyargs flit_core
+
+# Python 3.7: only test flit_core
+[testenv:py37]
+commands =
+    python -m pytest --cov=flit_core/flit_core --pyargs flit_core
+
 [testenv:bootstrap]
 skip_install = true
 # Make the install step a no-op, so nothing gets installed in the env


### PR DESCRIPTION
Python 3.7 is already end of life (security updates ended earlier this year), so we can bump the minimum version up.

As usual, I'm being more conservative with the compatibility of `flit_core`, so you can still build packages on older versions of Python.

Prompted by #658.