### PR TITLE
Documentation changes.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -11,8 +11,9 @@ Install
 
     $ python3 -m pip install flit
 or
+
 ::
-    
+
     $ pip3 install flit
 
 Flit requires Python 3 and therefore needs to be installed using the Python 3

--- a/README.rst
+++ b/README.rst
@@ -11,6 +11,8 @@ Install
 
     $ python3 -m pip install flit
 or
+::
+    
     $ pip3 install flit
 
 Flit requires Python 3 and therefore needs to be installed using the Python 3

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 **Flit** is a simple way to put Python packages and modules on PyPI.
-It tries to require less thought about packaging and help you avoid common
+It tries to require less thought about packaging and helps you avoid common
 mistakes.
 See `Why use Flit? <https://flit.readthedocs.io/en/latest/rationale.html>`_ for
 more about how it compares to other Python packaging tools.
@@ -59,7 +59,7 @@ or as a directory — and you want to distribute it.
        [project.urls]
        Home = "https://github.com/sirrobin/foobar"
 
-   You can edit this file to add other metadata, for example to set up
+   You can edit this file to add other metadata, for example, to set up
    command line scripts. See the
    `pyproject.toml page <https://flit.readthedocs.io/en/latest/pyproject_toml.html#scripts-section>`_
    of the documentation.
@@ -73,8 +73,8 @@ or as a directory — and you want to distribute it.
 
 Once your package is published, people can install it using *pip* just like
 any other package. In most cases, pip will download a 'wheel' package, a
-standard format it knows how to install. If you specifically ask pip to install
-an 'sdist' package, it will install and use Flit in a temporary environment.
+standard format it knows how to install. If you specifically ask Pip to install
+a 'sdist' package, it will install and use Flit in a temporary environment.
 
 
 To install a package locally for development, run::

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,7 @@ Install
 ::
 
     $ python3 -m pip install flit
+
 or
 
 ::

--- a/README.rst
+++ b/README.rst
@@ -73,7 +73,7 @@ or as a directory — and you want to distribute it.
 
 Once your package is published, people can install it using *pip* just like
 any other package. In most cases, pip will download a 'wheel' package, a
-standard format it knows how to install. If you specifically ask Pip to install
+standard format it knows how to install. If you specifically ask pip to install
 a 'sdist' package, it will install and use Flit in a temporary environment.
 
 

--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,8 @@ Install
 ::
 
     $ python3 -m pip install flit
+or
+    $ pip3 install flit
 
 Flit requires Python 3 and therefore needs to be installed using the Python 3
 version of pip.


### PR DESCRIPTION
In this request I fixed a few grammatical errors and added in another way to install Flit using `pip3 install flit` instead of `python3 -m pip install flit`.