### PR TITLE
Update Sphinx & sphinx-rtd-theme for RTD

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,3 +1,3 @@
-sphinx ~= 4.2
+sphinx ~= 7.0
 sphinxcontrib_github_alt ~= 1.2
-sphinx-rtd-theme ~= 1.0
+sphinx-rtd-theme ~= 2.0


### PR DESCRIPTION
The docs build on #667 failed, complaining that some extension requires a newer version of Sphinx.