### PR TITLE
Warn if packages still using flit.buildapi instead of flit_core.buildapi

### DIFF
--- a/flit/buildapi.py
+++ b/flit/buildapi.py
@@ -1,1 +1,6 @@
+from warnings import warn
+warn('A package has specified `build-backend = "flit.buildapi"` and is being '
+     'built with Flit >= 3.10. This is likely to break in a future version. '
+     'Please change the backend to flit_core.buildapi, and/or specify a '
+     'maximum version of Flit.')
 from flit_core.buildapi import *


### PR DESCRIPTION
I'm not 100% sold on this: the removal would break things that might otherwise work, and it's a tiny bit of complexity by itself. But any project still specifying `flit.buildapi` is probably also using old-style metadata (`[tool.flit.metadata]` table), which 4.0 will likely not support (#673), and that is enough complexity to be worth cleaning up.

- `flit.buildapi` added in 0.12 (November 2017)
- `flit_core.builadpi` added in 2.0 (November 2019)
- New-style metadata (`[project]` from PEP 621) added in 3.2 (March 2021)

Using `python -m build`, this warning is visible. Using `pip wheel` (and presumably any other pip command that does a build), it isn't (`pip wheel -v` shows it). I don't think there's anything we can do to make it more visible, but a warning that only some people see is better than no warning.

First step for #519