### PR TITLE
Implement Metadata 2.3

### DIFF
--- a/flit/upload.py
+++ b/flit/upload.py
@@ -226,7 +226,7 @@ def build_post_data(action, metadata:Metadata):
         "version": metadata.version,
 
         # additional meta-data
-        "metadata_version": '2.1',
+        "metadata_version": '2.3',
         "summary": metadata.summary,
         "home_page": metadata.home_page,
         "author": metadata.author,

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -347,6 +347,7 @@ class Metadata(object):
     obsoletes_dist = ()
     requires_external = ()
     provides_extra = ()
+    dynamic = ()
 
     metadata_version = "2.3"
 

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -348,7 +348,7 @@ class Metadata(object):
     requires_external = ()
     provides_extra = ()
 
-    metadata_version = "2.1"
+    metadata_version = "2.3"
 
     def __init__(self, data):
         data = data.copy()
@@ -359,8 +359,12 @@ class Metadata(object):
             assert hasattr(self, k), "data does not have attribute '{}'".format(k)
             setattr(self, k, v)
 
-    def _normalise_name(self, n):
+    def _normalise_field_name(self, n):
         return n.lower().replace('-', '_')
+
+    def _normalise_core_metadata_name(self, name):
+        # Normalized Names (PEP 503)
+        return re.sub(r"[-_.]+", "-", name).lower()
 
     def write_metadata_file(self, fp):
         """Write out metadata in the email headers format"""
@@ -383,11 +387,11 @@ class Metadata(object):
         ]
 
         for field in fields:
-            value = getattr(self, self._normalise_name(field))
+            value = getattr(self, self._normalise_field_name(field))
             fp.write(u"{}: {}\n".format(field, value))
 
         for field in optional_fields:
-            value = getattr(self, self._normalise_name(field))
+            value = getattr(self, self._normalise_field_name(field))
             if value is not None:
                 # TODO: verify which fields can be multiline
                 # The spec has multiline examples for Author, Maintainer &
@@ -400,13 +404,15 @@ class Metadata(object):
             fp.write(u'Classifier: {}\n'.format(clsfr))
 
         for req in self.requires_dist:
-            fp.write(u'Requires-Dist: {}\n'.format(req))
+            normalised_req = self._normalise_core_metadata_name(req)
+            fp.write(u'Requires-Dist: {}\n'.format(normalised_req))
 
         for url in self.project_urls:
             fp.write(u'Project-URL: {}\n'.format(url))
 
         for extra in self.provides_extra:
-            fp.write(u'Provides-Extra: {}\n'.format(extra))
+            normalised_extra = self._normalise_core_metadata_name(extra)
+            fp.write(u'Provides-Extra: {}\n'.format(normalised_extra))
 
         if self.description is not None:
             fp.write(u'\n' + self.description + u'\n')

--- a/flit_core/flit_core/tests/test_common.py
+++ b/flit_core/flit_core/tests/test_common.py
@@ -163,6 +163,10 @@ def test_metadata_multiline(tmp_path):
         ('foo [extra_1, extra.2, extra-3, extra__4, extra..5, extra--6]', 'foo [extra-1, extra-2, extra-3, extra-4, extra-5, extra-6]'),
         ('foo', 'foo'),
         ('foo[bar]', 'foo[bar]'),
+        # https://packaging.python.org/en/latest/specifications/core-metadata/#requires-dist-multiple-use
+        ('pkginfo', 'pkginfo'),
+        ('zope.interface (>3.5.0)', 'zope.interface (>3.5.0)'),
+        ("pywin32 >1.0; sys_platform == 'win32'", "pywin32 >1.0; sys_platform == 'win32'"),
     ],
 )
 def test_metadata_2_3_requires_dist(requires_dist, expected_result):


### PR DESCRIPTION
[PEP 643](https://peps.python.org/pep-0643/) introduces Metadata 2.2, where fields can either be static (default) or marked as dynamic. 
[PEP 685](https://peps.python.org/pep-0685/) introduces Metadata 2.3, that specifies how to normalize extra names.

This PR bumps the Metadata version to 2.3. `flit` has always written and published static metadata in both wheel `METADATA` and sdist `PKG-INFO` and therefore this PR does not intend to add new support for recording dynamic metadata into distributions. This should not be confused with the `dynamic` metadata in the pyproject.toml files, which are dynamic in flit and remain supported (PEP 621).

Upgrading to the newer Core Metadata standards has advantages for the python packaging ecosystem. It makes it possible for resolvers to read metadata directly without a PEP 517 invocation, which can bring large speedups.

Towards: https://github.com/pypa/flit/issues/675