### PR TITLE
Add an exclude patttern for wheels (and use it for flit-core)

### DIFF
--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -129,7 +129,7 @@ def prep_toml_config(d, path):
         )
 
     unknown_sections = set(dtool) - {
-        'metadata', 'module', 'scripts', 'entrypoints', 'sdist', 'external-data'
+        'metadata', 'module', 'scripts', 'entrypoints', 'sdist', 'wheel', 'external-data'
     }
     unknown_sections = [s for s in unknown_sections if not s.lower().startswith('x-')]
     if unknown_sections:
@@ -153,6 +153,17 @@ def prep_toml_config(d, path):
         ] + dtool['sdist'].get('exclude', [])
         loaded_cfg.sdist_exclude_patterns = _check_glob_patterns(
             exclude, 'exclude'
+        )
+
+    if 'wheel' in dtool:
+        unknown_keys = set(dtool['wheel']) - {'exclude'}
+        if unknown_keys:
+            raise ConfigError(
+                "Unknown keys in [tool.flit.wheel]:" + ", ".join(unknown_keys)
+            )
+
+        loaded_cfg.wheel_exclude_patterns = _check_glob_patterns(
+            dtool['wheel'].get('exclude', []), 'exclude'
         )
 
     data_dir = dtool.get('external-data', {}).get('directory', None)

--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -266,6 +266,7 @@ class LoadedConfig(object):
         self.referenced_files = []
         self.sdist_include_patterns = []
         self.sdist_exclude_patterns = []
+        self.wheel_exclude_patterns = []
         self.dynamic_metadata = []
         self.data_directory = None
 

--- a/flit_core/flit_core/sdist.py
+++ b/flit_core/flit_core/sdist.py
@@ -1,6 +1,5 @@
 from collections import defaultdict
 from copy import copy
-from glob import glob
 from gzip import GzipFile
 import io
 import logging
@@ -34,36 +33,6 @@ def clean_tarinfo(ti, mtime=None):
     return ti
 
 
-class FilePatterns:
-    """Manage a set of file inclusion/exclusion patterns relative to basedir"""
-    def __init__(self, patterns, basedir):
-        self.basedir = basedir
-
-        self.dirs = set()
-        self.files = set()
-
-        for pattern in patterns:
-            for path in sorted(glob(osp.join(basedir, pattern), recursive=True)):
-                rel = osp.relpath(path, basedir)
-                if osp.isdir(path):
-                    self.dirs.add(rel)
-                else:
-                    self.files.add(rel)
-
-    def match_file(self, rel_path):
-        if rel_path in self.files:
-            return True
-
-        return any(rel_path.startswith(d + os.sep) for d in self.dirs)
-
-    def match_dir(self, rel_path):
-        if rel_path in self.dirs:
-            return True
-
-        # Check if it's a subdirectory of any directory in the list
-        return any(rel_path.startswith(d + os.sep) for d in self.dirs)
-
-
 class SdistBuilder:
     """Builds a minimal sdist
 
@@ -80,8 +49,8 @@ class SdistBuilder:
         self.entrypoints = entrypoints
         self.extra_files = extra_files
         self.data_directory = data_directory
-        self.includes = FilePatterns(include_patterns, str(cfgdir))
-        self.excludes = FilePatterns(exclude_patterns, str(cfgdir))
+        self.includes = common.FilePatterns(include_patterns, str(cfgdir))
+        self.excludes = common.FilePatterns(exclude_patterns, str(cfgdir))
 
     @classmethod
     def from_ini_path(cls, ini_path: Path):

--- a/flit_core/pyproject.toml
+++ b/flit_core/pyproject.toml
@@ -25,3 +25,6 @@ Source = "https://github.com/pypa/flit"
 
 [tool.flit.sdist]
 include = ["bootstrap_install.py", "build_dists.py"]
+
+[tool.flit.wheel]
+exclude = ["flit_core/tests"]


### PR DESCRIPTION
Allows files to be included in the sdist but not installed.
Useful for established projects that have tests as a subdirectory of the
package directory.

----

flit-core 3.9.0 installs an `__init__.py` and 6 submodules plus 161 files (including byte-code files) in 44 directories
under a tests directory.

Draft because there is no documentation or tests at the moment. If there is a likelihood of it getting merged I can have a go at those.
