### PR TITLE
Normalise extra names when reading config

### DIFF
--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -370,10 +370,6 @@ class Metadata(object):
     def _normalise_field_name(self, n):
         return n.lower().replace('-', '_')
 
-    def _normalise_core_metadata_name(self, name):
-        # Normalized Names (PEP 503)
-        return re.sub(r"[-_.]+", "-", name).lower()
-
     def _extract_extras(self, req):
         match = re.search(r'\[([^]]*)\]', req)
         if match:
@@ -385,7 +381,7 @@ class Metadata(object):
     def _normalise_requires_dist(self, req):
         extras = self._extract_extras(req)
         if extras:
-            normalised_extras = [self._normalise_core_metadata_name(extra) for extra in extras]
+            normalised_extras = [normalise_core_metadata_name(extra) for extra in extras]
             normalised_extras_str = ', '.join(normalised_extras)
             normalised_req = re.sub(r'\[([^]]*)\]', f"[{normalised_extras_str}]", req)
             return normalised_req
@@ -437,7 +433,7 @@ class Metadata(object):
             fp.write(u'Project-URL: {}\n'.format(url))
 
         for extra in self.provides_extra:
-            normalised_extra = self._normalise_core_metadata_name(extra)
+            normalised_extra = normalise_core_metadata_name(extra)
             fp.write(u'Provides-Extra: {}\n'.format(normalised_extra))
 
         if self.description is not None:
@@ -458,6 +454,10 @@ def make_metadata(module, ini_info):
     md_dict.update(ini_info.metadata)
     return Metadata(md_dict)
 
+
+def normalise_core_metadata_name(name):
+    """Normalise a project or extra name (as in PEP 503, also PEP 685)"""
+    return re.sub(r"[-_.]+", "-", name).lower()
 
 
 def normalize_dist_name(name: str, version: str) -> str:

--- a/flit_core/tests_core/samples/extras-newstyle.toml
+++ b/flit_core/tests_core/samples/extras-newstyle.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = ["flit_core >=2,<4"]
+build-backend = "flit_core.buildapi"
+
+[project]
+name = "module1"
+version = "0.1"
+description = "Example for testing"
+dependencies = ["toml"]
+
+[project.optional-dependencies]
+test = ["pytest"]
+cus__Tom = ["requests"]  # To test normalisation

--- a/flit_core/tests_core/samples/extras.toml
+++ b/flit_core/tests_core/samples/extras.toml
@@ -12,4 +12,4 @@ requires = ["toml"]
 
 [tool.flit.metadata.requires-extra]
 test = ["pytest"]
-custom = ["requests"]
+cus__Tom = ["requests"]  # To test normalisation

--- a/flit_core/tests_core/test_config.py
+++ b/flit_core/tests_core/test_config.py
@@ -81,9 +81,20 @@ def test_extras():
     assert requires_dist == {
         'toml',
         'pytest ; extra == "test"',
-        'requests ; extra == "custom"',
+        'requests ; extra == "cus-tom"',
     }
-    assert set(info.metadata['provides_extra']) == {'test', 'custom'}
+    assert set(info.metadata['provides_extra']) == {'test', 'cus-tom'}
+
+def test_extras_newstyle():
+    # As above, but with new-style [project] table
+    info = config.read_flit_config(samples_dir / 'extras-newstyle.toml')
+    requires_dist = set(info.metadata['requires_dist'])
+    assert requires_dist == {
+        'toml',
+        'pytest ; extra == "test"',
+        'requests ; extra == "cus-tom"',
+    }
+    assert set(info.metadata['provides_extra']) == {'test', 'cus-tom'}
 
 def test_extras_dev_conflict():
     with pytest.raises(config.ConfigError, match=r'dev-requires'):
@@ -141,6 +152,10 @@ def test_bad_include_paths(path, err_match):
     ({'dynamic': ['version']}, r'dynamic.*\[project\]'),
     ({'authors': ['thomas']}, r'author.*\bdict'),
     ({'maintainers': [{'title': 'Dr'}]}, r'maintainer.*title'),
+    ({'name': 'mödule1'}, r'not valid'),
+    ({'name': 'module1_'}, r'not valid'),
+    ({'optional-dependencies': {'x_': []}}, r'not valid'),
+    ({'optional-dependencies': {'x_a': [], 'X--a': []}}, r'clash'),
 ])
 def test_bad_pep621_info(proj_bad, err_match):
     proj = {'name': 'module1', 'version': '1.0', 'description': 'x'}


### PR DESCRIPTION
This is a follow-up to #676.

PEP 685 only explicitly says that extra names should be normalised in `Provides-Extra` and in `foo[bar]` extra markers (specifying an extra dependency group of `foo`), but it seems like a good idea to ensure they're also normalised in `foo; extra='bar'` environment markers (specifying an optional dependency as part of our own extra). This ensures that.

Doing the normalisation when reading the config also allows for better error messages if two extra names normalise to the same value. I also added checking of [valid names](https://packaging.python.org/en/latest/specifications/name-normalization/#name-format) to fail quicker on invalid names.