### PR TITLE
Pypi.io does not exists anymore.

### DIFF
--- a/flit/upload.py
+++ b/flit/upload.py
@@ -28,7 +28,6 @@ SWITCH_TO_HTTPS = (
     "http://pypi.python.org/",
     "http://testpypi.python.org/",
     "http://upload.pypi.org/",
-    "http://upload.pypi.io/",
 )
 
 


### PR DESCRIPTION
It was a temporary url, still redirect for some GET but should not be used.