### PR TITLE
Provide token to upload coverage data to codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,8 @@ jobs:
         run: tox
 
       - name: Codecov upload
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: codecov
 
   test-py36:
@@ -63,6 +65,8 @@ jobs:
         run: tox
 
       - name: Codecov upload
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: codecov
 
 


### PR DESCRIPTION
Codecov is adding an extra ~20 seconds to each CI job, because it hits a rate limit and retries several times before timing out. I think giving it the token should work around this.