### PR TITLE
Add tox posargs

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -28,17 +28,17 @@ setenv =
     PYTHONPATH = flit_core
 
 commands =
-    python -m pytest --cov=flit --cov=flit_core/flit_core
+    python -m pytest --cov=flit --cov=flit_core/flit_core {posargs}
 
 # Python 3.6: only test flit_core
 [testenv:py36]
 commands =
-    python -m pytest --cov=flit_core/flit_core flit_core
+    python -m pytest --cov=flit_core/flit_core flit_core {posargs}
 
 # Python 3.7: only test flit_core
 [testenv:py37]
 commands =
-    python -m pytest --cov=flit_core/flit_core flit_core
+    python -m pytest --cov=flit_core/flit_core flit_core {posargs}
 
 [testenv:bootstrap]
 skip_install = true


### PR DESCRIPTION
Substitution with `{posargs}` allows devs to pass additional arguments to the tox command. Especially helpful if you like to run only a subset of tests for debugging. E.g
```
tox -e py313 -- --no-cov flit_core/tests_core/test_config.py

# would run
py313: commands[0]> python -m pytest --cov=flit --cov=flit_core/flit_core --no-cov flit_core/tests_core/test_config.py
```

https://tox.wiki/en/latest/config.html#substitutions-for-positional-arguments-in-commands