### PR TITLE
remove compliance code for py<3.8 AST

### DIFF
--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -148,10 +148,7 @@ def get_docstring_and_version_via_ast(target):
         with target_path.open('rb') as f:
             node = ast.parse(f.read())
         for child in node.body:
-            if sys.version_info >= (3, 8):
-                target_type = ast.Constant
-            else:
-                target_type = ast.Str
+            target_type = ast.Constant
             # Only use the version from the given module if it's a simple
             # string assignment to __version__
             is_version_str = (
@@ -164,10 +161,7 @@ def get_docstring_and_version_via_ast(target):
                     and isinstance(child.value, target_type)
             )
             if is_version_str:
-                if sys.version_info >= (3, 8):
-                    version = child.value.value
-                else:
-                    version = child.value.s
+                version = child.value.value
                 break
     return ast.get_docstring(node), version
 


### PR DESCRIPTION
since we do not support py<3.8 anymore these code can be safely removed