### PR TITLE
Move Python 3.7 tests to Ubuntu 22.04

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,33 @@ jobs:
     strategy:
       matrix:
         platform: ["ubuntu-latest", "windows-latest"]
-        python-version: [ "3.7", "3.8", "3.9", "3.10", "3.11" , "3.12", "3.13" ]
+        python-version: [ "3.8", "3.9", "3.10", "3.11" , "3.12", "3.13" ]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install tox tox-gh-actions codecov
+
+      - name: Run tests
+        run: tox
+
+      - name: Codecov upload
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+        run: codecov
+
+  test-py37:
+    runs-on: "ubuntu-22.04"
+    strategy:
+      matrix:
+        python-version: [ "3.7", ]
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
The `ubuntu-latest` platform on Github actions is now 24.04, and doesn't have Python 3.7 available any more.