### PR TITLE
Add support for license.text

### DIFF
--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -612,7 +612,9 @@ def read_pep621_metadata(proj, path) -> LoadedConfig:
                     raise ConfigError(f"License file {license_f} does not exist")
                 license_files.add(license_tbl['file'])
             elif 'text' in license_tbl:
-                pass
+                license = license_tbl['text']
+                # TODO Normalize license if it's a valid SPDX expression
+                md_dict['license'] = license
             else:
                 raise ConfigError(
                     "file or text field required in [project.license] table"

--- a/flit_core/tests_core/test_config.py
+++ b/flit_core/tests_core/test_config.py
@@ -208,6 +208,19 @@ def test_bad_pep621_readme(readme, err_match):
         config.read_pep621_metadata(proj, samples_dir / 'pep621' / 'pyproject.toml')
 
 
+@pytest.mark.parametrize(('value', 'license'), [
+    # Accept any string in project.license.text
+    ({"text": "mit"}, "mit"),
+    ({"text": "Apache Software License"}, "Apache Software License"),
+])
+def test_license_text(value, license):
+    proj = {
+        'name': 'module1', 'version': '1.0', 'description': 'x', 'license': value
+    }
+    info = config.read_pep621_metadata(proj, samples_dir / 'pep621' / 'pyproject.toml')
+    assert info.metadata['license'] == license
+
+
 @pytest.mark.parametrize(('value', 'license_expression'), [
     # Accept and normalize valid SPDX expressions for 'license = ...'
     ("mit",  "MIT"),


### PR DESCRIPTION
Before license expressions, the license table was allowed to contain a `text` key. That never got implemented even though the docs list it as supported. Map `license.text` to the `License` core metadata field.
https://github.com/pypa/flit/blob/2818f41fb2a6aedfd264c175ed3ca1434f39674b/doc/pyproject_toml.rst?plain=1#L98-L101

It seems this was accidentally removed in https://github.com/pypa/flit/pull/712/commits/f08bb9f0c6dee63b38f0d1e022ffbd8c67fb683b