### PR TITLE
Don't fail for complex license expressions

### DIFF
--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -823,6 +823,10 @@ def normalize_license_expr(s: str):
     """
     from ._spdx_data import licenses
     ls = s.lower()
+    if any(keyword in ls for keyword in ("and", "or", "with")):
+        # TODO complex license expressions
+        return s
+
     if ls.startswith('licenseref-'):
         ref = s.partition('-')[2]
         if re.match(r'([a-zA-Z0-9\-.])+$', ref):

--- a/flit_core/tests_core/test_config.py
+++ b/flit_core/tests_core/test_config.py
@@ -213,8 +213,11 @@ def test_bad_pep621_readme(readme, err_match):
     ("mit",  "MIT"),
     ("apache-2.0", "Apache-2.0"),
     ("APACHE-2.0+", "Apache-2.0+"),
-    # TODO: compound expressions
-    #("mit and (apache-2.0 or bsd-2-clause)", "MIT AND (Apache-2.0 OR BSD-2-Clause)"),
+    ("MIT AND BSD-2-Clause", "MIT AND BSD-2-Clause"),
+    ("MIT OR BSD-2-Clause", "MIT OR BSD-2-Clause"),
+    ("GPL-2.0-only WITH Classpath-exception-2.0", "GPL-2.0-only WITH Classpath-exception-2.0"),
+    # TODO: compound expressions should be checked and normalized
+    # ("mit and (apache-2.0 or bsd-2-clause)", "MIT AND (Apache-2.0 OR BSD-2-Clause)"),
     # LicenseRef expressions: only the LicenseRef is normalised
     ("LiceNseref-Public-DoMain", "LicenseRef-Public-DoMain"),
 ])


### PR DESCRIPTION
Flit should support complex license expressions with `AND`, `OR` or `WITH` and not raise `ConfigError`.
We can skip the validation here (for now). PyPI will always validated uploads.