### PR TITLE
More intuitive metadata when not all authors/maintainers have email addresses

### DIFF
--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -783,6 +783,7 @@ def name_is_valid(name) -> bool:
 def pep621_people(people, group_name='author') -> dict:
     """Convert authors/maintainers from PEP 621 to core metadata fields"""
     names, emails = [], []
+    names_without_emails = False
     for person in people:
         if not isinstance(person, dict):
             raise ConfigError("{} info must be list of dicts".format(group_name))
@@ -796,11 +797,15 @@ def pep621_people(people, group_name='author') -> dict:
             if 'name' in person:
                 email = str(Address(person['name'], addr_spec=email))
             emails.append(email)
-        elif 'name' in person:
+        if 'name' in person:
             names.append(person['name'])
+            if 'email' not in person:
+                names_without_emails = True
 
     res = {}
-    if names:
+    # The -Email fields include names (name <email>), so are preferred if
+    # everyone in the list provides an email address.
+    if names_without_emails:
         res[group_name] = ", ".join(names)
     if emails:
         res[group_name + '_email'] = ", ".join(emails)

--- a/flit_core/tests_core/samples/pep621/pyproject.toml
+++ b/flit_core/tests_core/samples/pep621/pyproject.toml
@@ -8,7 +8,8 @@ authors = [
     {name = "Sir Röbin", email = "robin@camelot.uk"}
 ]
 maintainers = [
-    {name = "Sir Galahad"}
+    {name = "Sir Galahad"},
+    {name = "Sir Bedevere", email = "bedevere@camelot.uk"}
 ]
 readme = "README.rst"
 license = {file = "LICENSE"}

--- a/flit_core/tests_core/test_config.py
+++ b/flit_core/tests_core/test_config.py
@@ -39,6 +39,9 @@ def test_load_pep621():
         'mock;extra=="test"and(python_version<\'3.6\')',
     }
     assert inf.metadata['author_email'] == "Sir Röbin <robin@camelot.uk>"
+    assert 'author' not in inf.metadata  # Skipped in favour of author_email
+    assert inf.metadata['maintainer_email'] == "Sir Bedevere <bedevere@camelot.uk>"
+    assert inf.metadata['maintainer'] == "Sir Galahad, Sir Bedevere"
     assert inf.entrypoints['flit_test_example']['foo'] == 'module1:main'
     assert set(inf.dynamic_metadata) == {'version', 'description'}
 


### PR DESCRIPTION
If some people only have names, list all names in the Author/Maintainer field. This could still be confusing if some people only have names and others only have email addresses, which is officially allowed, but... :shrug: 

Closes #720 