### PR TITLE
Support annotated assignment for ```__version__``` strings

### DIFF
--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -148,28 +148,27 @@ def get_docstring_and_version_via_ast(target):
         with target_path.open('rb') as f:
             node = ast.parse(f.read())
         for child in node.body:
-            if sys.version_info >= (3, 8):
-                target_type = ast.Constant
-            else:
-                target_type = ast.Str
-            # Only use the version from the given module if it's a simple
-            # string assignment to __version__
-            is_version_str = (
-                    isinstance(child, ast.Assign)
-                    and any(
-                        isinstance(target, ast.Name)
-                        and target.id == "__version__"
-                        for target in child.targets
-                    )
-                    and isinstance(child.value, target_type)
-            )
-            if is_version_str:
+            if is_version_str_node(child):
                 if sys.version_info >= (3, 8):
                     version = child.value.value
                 else:
                     version = child.value.s
                 break
     return ast.get_docstring(node), version
+
+
+def is_version_str_node(node, /):
+    """Check if *node* is a simple string assignment to __version__"""
+    if not isinstance(node, (ast.Assign, ast.AnnAssign)):
+        return False
+    constant_type = ast.Constant if sys.version_info >= (3, 8) else ast.Str
+    if not isinstance(node.value, constant_type):
+        return False
+    targets = (node.target,) if isinstance(node, ast.AnnAssign) else node.targets
+    for target in targets:
+        if isinstance(target, ast.Name) and target.id == "__version__":
+            return True
+    return False
 
 
 # To ensure we're actually loading the specified file, give it a unique name to

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -148,7 +148,7 @@ def get_docstring_and_version_via_ast(target):
         with target_path.open('rb') as f:
             node = ast.parse(f.read())
         for child in node.body:
-            if is_version_str_node(child):
+            if is_version_str_assignment(child):
                 if sys.version_info >= (3, 8):
                     version = child.value.value
                 else:
@@ -157,7 +157,7 @@ def get_docstring_and_version_via_ast(target):
     return ast.get_docstring(node), version
 
 
-def is_version_str_node(node, /):
+def is_version_str_assignment(node):
     """Check if *node* is a simple string assignment to __version__"""
     if not isinstance(node, (ast.Assign, ast.AnnAssign)):
         return False

--- a/flit_core/tests_core/samples/annotated_version/module1.py
+++ b/flit_core/tests_core/samples/annotated_version/module1.py
@@ -1,0 +1,4 @@
+
+"""This module has a __version__ that has a type annotation"""
+
+__version__: str = '0.1'

--- a/flit_core/tests_core/samples/annotated_version/pyproject.toml
+++ b/flit_core/tests_core/samples/annotated_version/pyproject.toml
@@ -1,0 +1,12 @@
+[build-system]
+requires = ["flit_core >=2,<4"]
+build-backend = "flit_core.buildapi"
+
+[tool.flit.metadata]
+module = "module1"
+author = "Sir Robin"
+author-email = "robin@camelot.uk"
+home-page = "http://github.com/sirrobin/module1"
+requires = [
+    "numpy >=1.16.0",
+]

--- a/flit_core/tests_core/test_common.py
+++ b/flit_core/tests_core/test_common.py
@@ -75,6 +75,11 @@ class ModuleTests(TestCase):
                                 'version': '0.1'}
                          )
 
+        info = get_info_from_module(Module('module1', samples_dir / 'annotated_version'))
+        self.assertEqual(info, {'summary': 'This module has a __version__ that has a type annotation',
+                                'version': '0.1'}
+                         )
+
         info = get_info_from_module(Module('module1', samples_dir / 'constructed_version'))
         self.assertEqual(info, {'summary': 'This module has a __version__ that requires runtime interpretation',
                                 'version': '1.2.3'}


### PR DESCRIPTION
I recently tried to update a package to use a ``Final`` annotation for the ``__version__`` attribute, but realised that Flit doesn't support annotated assignment. This PR adds support and tests.

A