### PR TITLE
Set up Ruff to lint imports

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,33 @@
+name: Lint source code
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: "1"
+
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
+
+    - name: Install Ruff
+      uses: astral-sh/ruff-action@v3
+      with:
+        args: --version
+
+    - name: Lint with Ruff
+      run: ruff check --output-format=github

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,3 +4,12 @@ repos:
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
+
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.9.9
+    hooks:
+      - id: ruff
+        name: "Lint with Ruff"
+        args:
+          - '--fix'
+          - '--exit-non-zero-on-fix'

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,19 @@
+target-version = "py38"  # Pin Ruff to Python 3.8
+output-format = "full"
+
+extend-exclude = [
+    "doc/*",
+    "flit/vendorized/*",
+    "flit_core/flit_core/vendor/*",
+]
+
+[lint]
+select = [
+    "F401",  # `{name}` imported but unused
+    "I",     # isort
+]
+
+[lint.per-file-ignores]
+"flit_core/tests_core/samples/*" = [
+    "F401",  # names may be unused in test samples
+]

--- a/bootstrap_dev.py
+++ b/bootstrap_dev.py
@@ -7,8 +7,8 @@
 import argparse
 import logging
 import os
-from pathlib import Path
 import sys
+from pathlib import Path
 
 my_dir = Path(__file__).parent
 os.chdir(str(my_dir))

--- a/flit/__init__.py
+++ b/flit/__init__.py
@@ -9,6 +9,7 @@ import sys
 from typing import Optional
 
 from flit_core import common
+
 from .config import ConfigError
 from .log import enable_colourful_output
 

--- a/flit/_get_dirs.py
+++ b/flit/_get_dirs.py
@@ -4,6 +4,7 @@ import os
 import sys
 import sysconfig
 
+
 def get_dirs(user=True):
     """Get the 'scripts' and 'purelib' directories we'll install into.
 

--- a/flit/build.py
+++ b/flit/build.py
@@ -1,15 +1,15 @@
 """flit build - build both wheel and sdist"""
 
-from contextlib import contextmanager
 import logging
 import os
-from pathlib import Path
+import sys
 import tarfile
+from contextlib import contextmanager
+from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
-import sys
 
-from .config import read_flit_config, ConfigError
+from .config import ConfigError, read_flit_config
 from .sdist import SdistBuilder
 from .wheel import make_wheel_in
 

--- a/flit/buildapi.py
+++ b/flit/buildapi.py
@@ -1,4 +1,5 @@
 from warnings import warn
+
 warn('A package has specified `build-backend = "flit.buildapi"` and is being '
      'built with Flit >= 3.10. This is likely to break in a future version. '
      'Please change the backend to flit_core.buildapi, and/or specify a '

--- a/flit/config.py
+++ b/flit/config.py
@@ -2,6 +2,7 @@ import os
 
 from flit_core.config import *
 from flit_core.config import read_flit_config as _read_flit_config_core
+
 from .validate import validate_config
 
 

--- a/flit/init.py
+++ b/flit/init.py
@@ -1,10 +1,12 @@
-from datetime import date
 import json
 import os
-from pathlib import Path
 import re
 import sys
+from datetime import date
+from pathlib import Path
+
 import tomli_w
+
 
 def get_data_dir():
     """Get the directory path for flit user data files.

--- a/flit/install.py
+++ b/flit/install.py
@@ -1,23 +1,23 @@
 """Install packages locally for development
 """
+import csv
+import json
 import logging
 import os
 import os.path as osp
-import csv
-import json
 import pathlib
 import random
 import shutil
 import site
 import sys
+import sysconfig
 import tempfile
 from subprocess import check_call, check_output
-import sysconfig
 
 from flit_core import common
-from .config import read_flit_config
-from .wheel import WheelBuilder
+
 from ._get_dirs import get_dirs
+from .config import read_flit_config
 
 log = logging.getLogger(__name__)
 

--- a/flit/sdist.py
+++ b/flit/sdist.py
@@ -1,15 +1,15 @@
-from collections import defaultdict
 import io
 import logging
 import os
+import tarfile
+from collections import defaultdict
 from pathlib import Path
 from posixpath import join as pjoin
 from pprint import pformat
-import tarfile
 
-from flit_core.sdist import SdistBuilder as SdistBuilderCore
-from flit_core.common import Module, VCSError
 from flit.vcs import identify_vcs
+from flit_core.common import Module, VCSError
+from flit_core.sdist import SdistBuilder as SdistBuilderCore
 
 log = logging.getLogger(__name__)
 

--- a/flit/tomlify.py
+++ b/flit/tomlify.py
@@ -1,14 +1,14 @@
 """Convert a flit.ini file to pyproject.toml
 """
 import argparse
-from collections import OrderedDict
 import configparser
 import os
+from collections import OrderedDict
 from pathlib import Path
+
 import tomli_w
 
 from .config import metadata_list_fields
-
 
 TEMPLATE = """\
 [build-system]

--- a/flit/upload.py
+++ b/flit/upload.py
@@ -8,15 +8,17 @@ import getpass
 import hashlib
 import logging
 import os
-from pathlib import Path
 import re
-import requests
 import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Optional
 from urllib.parse import urlparse
 
-from flit_core.common import make_metadata, Metadata, Module
+import requests
+
+from flit_core.common import Metadata, Module, make_metadata
+
 from .config import read_flit_config
 
 log = logging.getLogger(__name__)
@@ -162,7 +164,8 @@ def write_pypirc(repo, file="~/.pypirc"):
 
 def get_password(repo: RepoDetails):
     try:
-        import keyring, keyring.errors
+        import keyring
+        import keyring.errors
     except ImportError:  # pragma: no cover
         log.warning("Install keyring to store tokens/passwords securely")
         keyring = None
@@ -202,7 +205,8 @@ def find_token(repo: RepoDetails, project_name: str):
         candidate_keys.append(f"pypi_token:user:{repo.username}")
 
     try:
-        import keyring, keyring.errors
+        import keyring
+        import keyring.errors
     except ImportError:  # pragma: no cover
         pass
     else:

--- a/flit/validate.py
+++ b/flit/validate.py
@@ -4,10 +4,11 @@ import errno
 import io
 import logging
 import os
-from pathlib import Path
 import re
-import requests
 import sys
+from pathlib import Path
+
+import requests
 
 from .vendorized.readme.rst import render
 

--- a/flit/vcs/__init__.py
+++ b/flit/vcs/__init__.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
-from . import hg
-from . import git
+from . import git, hg
+
 
 def identify_vcs(directory: Path):
     directory = directory.resolve()

--- a/flit_core/bootstrap_install.py
+++ b/flit_core/bootstrap_install.py
@@ -17,6 +17,7 @@ import sysconfig
 from pathlib import Path
 from zipfile import ZipFile
 
+
 def extract_wheel(whl_path, dest):
     print("Installing to", dest)
     with ZipFile(whl_path) as zf:

--- a/flit_core/flit_core/buildapi.py
+++ b/flit_core/flit_core/buildapi.py
@@ -1,17 +1,20 @@
 """PEP-517 compliant buildsystem API"""
-import logging
 import io
+import logging
 import os
 import os.path as osp
 from pathlib import Path
 
 from .common import (
-    Module, make_metadata, write_entry_points, dist_info_name,
+    Module,
+    dist_info_name,
     get_docstring_and_version_via_ast,
+    make_metadata,
+    write_entry_points,
 )
 from .config import read_flit_config
-from .wheel import make_wheel_in, _write_wheel_file
 from .sdist import SdistBuilder
+from .wheel import _write_wheel_file, make_wheel_in
 
 log = logging.getLogger(__name__)
 

--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -1,16 +1,16 @@
 import ast
-from contextlib import contextmanager
 import hashlib
 import logging
 import os
-import sys
-
-from pathlib import Path
 import re
+import sys
+from contextlib import contextmanager
+from pathlib import Path
 
 log = logging.getLogger(__name__)
 
 from .versionno import normalise_version
+
 
 class Module(object):
     """This represents the module/package that we are going to distribute
@@ -187,7 +187,7 @@ def get_docstring_and_version_via_import(target):
     _import_i += 1
 
     log.debug("Loading module %s", target.file)
-    from importlib.util import spec_from_file_location, module_from_spec
+    from importlib.util import module_from_spec, spec_from_file_location
     mod_name = 'flit_core.dummy.import%d' % _import_i
     spec = spec_from_file_location(mod_name, target.file)
     with _module_load_ctx():

--- a/flit_core/flit_core/config.py
+++ b/flit_core/flit_core/config.py
@@ -1,12 +1,11 @@
 import difflib
-from email.headerregistry import Address
 import errno
 import logging
 import os
 import os.path as osp
-from os.path import isabs
-from pathlib import Path
 import re
+from email.headerregistry import Address
+from pathlib import Path
 
 try:
     import tomllib

--- a/flit_core/flit_core/sdist.py
+++ b/flit_core/flit_core/sdist.py
@@ -1,14 +1,14 @@
-from collections import defaultdict
-from copy import copy
-from glob import glob
-from gzip import GzipFile
 import io
 import logging
 import os
 import os.path as osp
+import tarfile
+from collections import defaultdict
+from copy import copy
+from glob import glob
+from gzip import GzipFile
 from pathlib import Path
 from posixpath import join as pjoin
-import tarfile
 
 from . import common
 

--- a/flit_core/flit_core/vendor/tomli/_parser.py
+++ b/flit_core/flit_core/vendor/tomli/_parser.py
@@ -1,7 +1,7 @@
 import string
+import warnings
 from types import MappingProxyType
 from typing import Any, BinaryIO, Dict, FrozenSet, Iterable, NamedTuple, Optional, Tuple
-import warnings
 
 from ._re import (
     RE_DATETIME,

--- a/flit_core/flit_core/vendor/tomli/_re.py
+++ b/flit_core/flit_core/vendor/tomli/_re.py
@@ -1,6 +1,6 @@
+import re
 from datetime import date, datetime, time, timedelta, timezone, tzinfo
 from functools import lru_cache
-import re
 from typing import Any, Optional, Union
 
 from ._types import ParseFloat

--- a/flit_core/flit_core/wheel.py
+++ b/flit_core/flit_core/wheel.py
@@ -1,7 +1,5 @@
 import argparse
-from base64 import urlsafe_b64encode
 import contextlib
-from datetime import datetime, timezone
 import hashlib
 import io
 import logging
@@ -9,12 +7,15 @@ import os
 import os.path as osp
 import stat
 import tempfile
+import zipfile
+from base64 import urlsafe_b64encode
+from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
 from typing import Optional
-import zipfile
 
 from flit_core import __version__
+
 from . import common
 
 log = logging.getLogger(__name__)

--- a/flit_core/tests_core/samples/imported_version/package1/__init__.py
+++ b/flit_core/tests_core/samples/imported_version/package1/__init__.py
@@ -1,5 +1,5 @@
 """This module has a __version__ that requires a relative import"""
 
-from ._version import __version__
-
 import a_package_that_doesnt_exist
+
+from ._version import __version__

--- a/flit_core/tests_core/test_build_thyself.py
+++ b/flit_core/tests_core/test_build_thyself.py
@@ -1,12 +1,14 @@
 """Tests of flit_core building itself"""
 import os
 import os.path as osp
-import pytest
 import tarfile
-from testpath import assert_isdir, assert_isfile
 import zipfile
 
+import pytest
+from testpath import assert_isdir, assert_isfile
+
 from flit_core import buildapi
+
 
 @pytest.fixture()
 def cwd_project():

--- a/flit_core/tests_core/test_buildapi.py
+++ b/flit_core/tests_core/test_buildapi.py
@@ -1,10 +1,11 @@
-from contextlib import contextmanager
 import os
 import os.path as osp
 import tarfile
-from testpath import assert_isfile, assert_isdir
-from testpath.tempdir import TemporaryDirectory
 import zipfile
+from contextlib import contextmanager
+
+from testpath import assert_isdir, assert_isfile
+from testpath.tempdir import TemporaryDirectory
 
 from flit_core import buildapi
 

--- a/flit_core/tests_core/test_common.py
+++ b/flit_core/tests_core/test_common.py
@@ -2,13 +2,20 @@ import email.parser
 import email.policy
 from io import StringIO
 from pathlib import Path
-import pytest
 from unittest import TestCase
+
+import pytest
 
 from flit_core import config
 from flit_core.common import (
-    Module, get_info_from_module, InvalidVersion, NoVersionError, check_version,
-    normalize_file_permissions, Metadata, make_metadata,
+    InvalidVersion,
+    Metadata,
+    Module,
+    NoVersionError,
+    check_version,
+    get_info_from_module,
+    make_metadata,
+    normalize_file_permissions,
 )
 
 samples_dir = Path(__file__).parent / 'samples'

--- a/flit_core/tests_core/test_config.py
+++ b/flit_core/tests_core/test_config.py
@@ -2,6 +2,7 @@ import logging
 import re
 import sys
 from pathlib import Path
+
 import pytest
 
 from flit_core import config

--- a/flit_core/tests_core/test_sdist.py
+++ b/flit_core/tests_core/test_sdist.py
@@ -1,7 +1,8 @@
-from io import BytesIO
 import os.path as osp
-from pathlib import Path
 import tarfile
+from io import BytesIO
+from pathlib import Path
+
 from testpath import assert_isfile
 
 from flit_core import sdist

--- a/flit_core/tests_core/test_versionno.py
+++ b/flit_core/tests_core/test_versionno.py
@@ -3,6 +3,7 @@ import pytest
 from flit_core.common import InvalidVersion
 from flit_core.versionno import normalise_version
 
+
 def test_normalise_version():
     nv = normalise_version
     assert nv('4.3.1') == '4.3.1'

--- a/flit_core/tests_core/test_wheel.py
+++ b/flit_core/tests_core/test_wheel.py
@@ -3,7 +3,7 @@ from zipfile import ZipFile
 
 from testpath import assert_isfile
 
-from flit_core.wheel import make_wheel_in, main
+from flit_core.wheel import main, make_wheel_in
 
 samples_dir = Path(__file__).parent / 'samples'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,9 @@ doc = [
 	"sphinxcontrib_github_alt",
 	"pygments-github-lexers",  # TOML highlighting
 ]
+lint = [
+    "ruff==0.9.9",
+]
 
 [project.urls]
 Documentation = "https://flit.pypa.io"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 from pathlib import Path
-import pytest
 from shutil import copytree
+
+import pytest
 
 samples_dir = Path(__file__).parent / 'samples'
 

--- a/tests/test_build.py
+++ b/tests/test_build.py
@@ -1,12 +1,13 @@
-from pathlib import Path
-import pytest
 import shutil
 import sys
+from pathlib import Path
 from tempfile import TemporaryDirectory
-from testpath import assert_isdir, MockCommand
 
-from flit_core import common
+import pytest
+from testpath import MockCommand, assert_isdir
+
 from flit import build
+from flit_core import common
 
 samples_dir = Path(__file__).parent / 'samples'
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,5 +1,6 @@
-from subprocess import Popen, PIPE, STDOUT
 import sys
+from subprocess import PIPE, STDOUT, Popen
+
 
 def test_flit_help():
     p = Popen([sys.executable, '-m', 'flit', '--help'], stdout=PIPE, stderr=STDOUT)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,8 @@
 from pathlib import Path
+
 import pytest
 
-from flit.config import read_flit_config, ConfigError
+from flit.config import ConfigError, read_flit_config
 
 samples_dir = Path(__file__).parent / 'samples'
 

--- a/tests/test_find_python_executable.py
+++ b/tests/test_find_python_executable.py
@@ -1,8 +1,8 @@
-from os.path import isabs, basename, dirname
 import os
 import re
 import sys
 import venv
+from os.path import basename, dirname, isabs
 
 import pytest
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -2,9 +2,10 @@ import builtins
 from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from testpath import assert_isfile
 from unittest.mock import patch
+
 import pytest
+from testpath import assert_isfile
 
 try:
     import tomllib

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -3,16 +3,20 @@ import os
 import pathlib
 import sys
 import tempfile
-from unittest import TestCase, SkipTest, skipIf
+from unittest import SkipTest, TestCase, skipIf
 from unittest.mock import patch
 
 import pytest
 from testpath import (
-    assert_isfile, assert_isdir, assert_islink, assert_not_path_exists, MockCommand
+    MockCommand,
+    assert_isdir,
+    assert_isfile,
+    assert_islink,
+    assert_not_path_exists,
 )
 
 from flit import install
-from flit.install import Installer, _requires_dist_to_pip_requirement, DependencyError
+from flit.install import DependencyError, Installer, _requires_dist_to_pip_requirement
 
 tests_dir = pathlib.Path(__file__).parent
 samples_dir = tests_dir / 'samples'

--- a/tests/test_sdist.py
+++ b/tests/test_sdist.py
@@ -1,14 +1,15 @@
 import ast
-from os.path import join as pjoin
-from pathlib import Path
-import pytest
-from shutil import which, copy, copytree
 import sys
 import tarfile
+from os.path import join as pjoin
+from pathlib import Path
+from shutil import copytree, which
 from tempfile import TemporaryDirectory
-from testpath import assert_isfile, MockCommand
 
-from flit import sdist, common
+import pytest
+from testpath import MockCommand, assert_isfile
+
+from flit import common, sdist
 
 samples_dir = Path(__file__).parent / 'samples'
 

--- a/tests/test_tomlify.py
+++ b/tests/test_tomlify.py
@@ -1,10 +1,9 @@
-import os
 from pathlib import Path
+
 try:
     import tomllib
 except ImportError:
     import tomli as tomllib
-from shutil import copy
 from testpath import assert_isfile
 
 from flit import tomlify

--- a/tests/test_upload.py
+++ b/tests/test_upload.py
@@ -1,18 +1,17 @@
+import io
+import os
+import pathlib
 from contextlib import contextmanager
 from tempfile import NamedTemporaryFile
-import os
-import io
-import pathlib
-import sys
+from unittest.mock import patch
 
 import pytest
 import responses
 from testpath import modified_env
-from unittest.mock import patch
 
 from flit import upload
 from flit.build import ALL_FORMATS
-from flit.upload import get_repository, RepoDetails
+from flit.upload import RepoDetails, get_repository
 
 samples_dir = pathlib.Path(__file__).parent / 'samples'
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,8 +1,10 @@
 import errno
+
 import pytest
 import responses
 
 from flit import validate as fv
+
 
 def test_validate_entrypoints():
     assert fv.validate_entrypoints(

--- a/tests/test_vcs.py
+++ b/tests/test_vcs.py
@@ -1,9 +1,10 @@
-from contextlib import contextmanager
 import os
+from contextlib import contextmanager
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from flit import vcs
+
 
 @contextmanager
 def cwd(path):

--- a/tests/test_wheel.py
+++ b/tests/test_wheel.py
@@ -1,16 +1,16 @@
 import configparser
 import os
 import stat
-from pathlib import Path
 import tempfile
-from unittest import skipIf
 import zipfile
+from pathlib import Path
+from unittest import skipIf
 
 import pytest
-from testpath import assert_isfile, assert_isdir, assert_not_path_exists
+from testpath import assert_isdir, assert_isfile, assert_not_path_exists
 
-from flit.wheel import WheelBuilder, make_wheel_in
 from flit.config import EntryPointsConflict
+from flit.wheel import WheelBuilder, make_wheel_in
 
 samples_dir = Path(__file__).parent / 'samples'
 


### PR DESCRIPTION
From #732, I personally find it useful to have a tool check these things automatically for me.

This PR proposes a minimal Ruff configuration, setting up only unused import detection (F401) and import sorting. I've also taken the liberty to propose a GitHub workflow to check this.

However, I saw in @cdce8p's #726 that you "don't generally favour large-scale code cleanups or strict enforcement of style rules", so I won't be saddened if this PR gets rejected -- see it as just a suggestion of what might be useful!

A

---

N.B. There are several options to configure import sorting, e.g. [`force-sort-within-sections`](https://docs.astral.sh/ruff/settings/#lint_isort_force-sort-within-sections). I'm not sure if you have pre-existing preferences, so I just went with the isort defaults to begin with.