### PR TITLE
Update vendorized readme_renderer

### DIFF
--- a/flit/vendorized/readme/rst.py
+++ b/flit/vendorized/readme/rst.py
@@ -93,9 +93,10 @@ SETTINGS = {
     # Strip all comments from the rendered output.
     "strip_comments": True,
 
-    # Use the short form of syntax highlighting so that the generated
-    # Pygments CSS can be used to style the output.
-    "syntax_highlight": "short",
+    # PATCH FOR FLIT ----------------------------------
+    # Disable syntax highlighting so we don't need Pygments installed.
+    "syntax_highlight": "none",
+    # -------------------------------------------------
 
     # Maximum width (in characters) for one-column field names.
     # 0 means "no limit"


### PR DESCRIPTION
Update to 44.0 from 2024-07-08:
https://github.com/pypa/readme_renderer/releases/tag/44.0

Apply the previous patch 1092d13 / #357.