### PR TITLE
Allow flit_core 4.x in projects newly set up with 'flit init'

### DIFF
--- a/flit/init.py
+++ b/flit/init.py
@@ -236,7 +236,7 @@ class TerminalIniter(IniterBase):
 
 TEMPLATE = """\
 [build-system]
-requires = ["flit_core >=3.11,<4"]
+requires = ["flit_core >=3.11,<5"]
 build-backend = "flit_core.buildapi"
 
 [project]


### PR DESCRIPTION
I'm getting concrete about what will be changing in flit_core 4.0, and projects newly created with the defaults should be fine. See #673.