### PR TITLE
Use tarfile filter on Python >= 3.12 when extracting sdist

### DIFF
--- a/flit/build.py
+++ b/flit/build.py
@@ -21,7 +21,9 @@ ALL_FORMATS = {'wheel', 'sdist'}
 def unpacked_tarball(path):
     tf = tarfile.open(str(path))
     with TemporaryDirectory() as tmpdir:
-        tf.extractall(tmpdir)
+        # Py >=3.12: restrict advanced tar features which sdists shouldn't use
+        kw = {'filter': 'data'} if hasattr(tarfile, 'data_filter') else {}
+        tf.extractall(tmpdir, **kw)
         files = os.listdir(tmpdir)
         assert len(files) == 1, files
         yield os.path.join(tmpdir, files[0])


### PR DESCRIPTION
I'm doing this mainly to get rid of the deprecation warning saying that the default filter will change in 3.14. I don't think sdists should be using any of the fancier features in the tar format. If someone comes up with a valid use case why an sdist might need e.g. a symlink pointing outside of the archive, we could relax this, but as it wouldn't be supported in wheels anyway, it seems unlikely.