### PR TITLE
Adds handling of tuples for version

### DIFF
--- a/flit_core/flit_core/common.py
+++ b/flit_core/flit_core/common.py
@@ -251,6 +251,8 @@ def check_version(version):
     if not version:
         raise NoVersionError('Cannot package module without a version string. '
                              'Please define a `__version__ = "x.y.z"` in your module.')
+    if isinstance(version, tuple):
+        version = '.'.join(map(str, version))
     if not isinstance(version, str):
         raise InvalidVersion(f'__version__ must be a string, not {type(version)}.')
 

--- a/flit_core/tests_core/test_common.py
+++ b/flit_core/tests_core/test_common.py
@@ -101,13 +101,15 @@ class ModuleTests(TestCase):
             check_version('3!')
 
         with pytest.raises(InvalidVersion):
-            check_version((1, 2))
+            check_version((1, 'a', 2))
 
         with pytest.raises(NoVersionError):
             check_version(None)
 
         assert check_version('4.1.0beta1') == '4.1.0b1'
         assert check_version('v1.2') == '1.2'
+        assert check_version((1, 2, 3)) == '1.2.3'
+        assert check_version((4,1,0, 'beta1')) == '4.1.0b1'
 
 def test_normalize_file_permissions():
     assert normalize_file_permissions(0o100664) == 0o100644 # regular file


### PR DESCRIPTION
This change checks if the version is a tuple and then maps it to a string delimited by `.`. It then follows the natural path it does.

To use flit we need this for our [Apache project](https://github.com/apache/hamilton/blob/main/hamilton/version.py#L18).