### PR TITLE
Fix wheel file permissions being too restrictive

### DIFF
--- a/doc/history.rst
+++ b/doc/history.rst
@@ -1,6 +1,12 @@
 Release history
 ===============
 
+Version 4.0.3
+-------------
+
+- Fix built wheels being created with overly restrictive ``0600`` permissions
+  instead of the normal, world-readable ``0644`` (:ghpull:`806`).
+
 Version 4.0.2
 -------------
 

--- a/flit_core/flit_core/wheel.py
+++ b/flit_core/flit_core/wheel.py
@@ -222,6 +222,12 @@ def make_wheel_in(ini_path, wheel_directory, editable=False):
             wb = WheelBuilder.from_ini_path(ini_path, fp)
             wb.build(editable)
 
+        # mkstemp() creates the file with mode 0600, which is too strict
+        # for a build artifact - normalize it like the files inside the
+        # wheel are normalized.
+        st_mode = os.stat(temp_path).st_mode
+        os.chmod(temp_path, common.normalize_file_permissions(st_mode))
+
         wheel_path = wheel_directory / wb.wheel_filename
         os.replace(temp_path, str(wheel_path))
     except:

--- a/flit_core/tests_core/test_wheel.py
+++ b/flit_core/tests_core/test_wheel.py
@@ -1,6 +1,10 @@
+import os
+import stat
+import sys
 from pathlib import Path
 from zipfile import ZipFile
 
+import pytest
 from testpath import assert_isfile
 
 from flit_core.wheel import make_wheel_in, main
@@ -53,3 +57,15 @@ def test_license_files(tmp_path):
     with ZipFile(info.file, 'r') as zf:
         assert 'module1-0.1.dist-info/licenses/LICENSE' in zf.namelist()
         assert 'module1-0.1.dist-info/licenses/module/vendor/LICENSE_VENDOR' in zf.namelist()
+
+
+@pytest.mark.skipif(sys.platform == 'win32', reason='Windows does not have Unix file permissions')
+def test_wheel_file_permissions(tmp_path):
+    # mkstemp(), which is used to create the wheel before it's renamed to
+    # its final name, creates files with mode 0600. The built wheel file
+    # itself should not be left that restrictive. Regression test for
+    # https://github.com/pypa/flit/issues/804
+    info = make_wheel_in(samples_dir / 'pep621' / 'pyproject.toml', tmp_path)
+    assert_isfile(info.file)
+    mode = stat.S_IMODE(os.stat(info.file).st_mode)
+    assert mode & 0o777 == 0o644, oct(mode)


### PR DESCRIPTION
Fixes #804

`make_wheel_in()` builds the wheel in a temporary file created by `tempfile.mkstemp()`, which sets the file's permissions to `0600`. That mode was never relaxed before the temp file was renamed into its final `.whl` path, so built wheels ended up owner-only readable instead of the usual world-readable `0644`. This breaks setups where the wheel is later read by a different user (e.g. some CI/build pipelines).

The fix normalizes the temp file's permissions with the existing `normalize_file_permissions()` helper right before it's renamed into place, matching the same normalization already applied to the entries inside the wheel. Added a regression test that checks the built wheel's mode on disk.

Same root cause as pypa/hatch#1519, fixed there with the analogous `normalize_artifact_permissions()`.