### PR TITLE
Clarify import package terminology

### DIFF
--- a/doc/rationale.rst
+++ b/doc/rationale.rst
@@ -20,8 +20,9 @@ What, specifically, does Flit make easy?
 
 - ``flit init`` helps you set up the information Flit needs about your
   package.
-- Subpackages are automatically included: you only need to specify the
-  top-level package.
+- Import packages in subfolders are automatically included: specify only the
+  top-level import package (for example, ``django``), and Flit includes
+  subpackages such as ``django.db`` and ``django.db.models.sql``.
 - Data files within a package directory are automatically included.
   Missing data files has been a common packaging mistake with other tools.
 - The version number is taken from your package's ``__version__`` attribute,


### PR DESCRIPTION
## What

Clarify that Flit's top-level packages and automatically included subpackages are both import packages.

## Why

The existing wording could be read as mixing distribution-package and import-package terminology. The updated bullet uses the maintainer-provided `django` hierarchy to make the distinction explicit.

Fixes #618

## Testing

- warning-as-error Sphinx HTML build
- warning-as-error linkcheck for `doc/rationale.rst`
- scoped pre-commit hooks
- codespell
- `git diff --check`

The repository-wide linkcheck also reached an unrelated existing HTTP 403 for `docutils.sourceforge.io` in `doc/pyproject_toml.rst`; the edited page's links all passed.
