### PR TITLE
Better tests for metadata format

### DIFF
--- a/flit_core/tests_core/test_build_thyself.py
+++ b/flit_core/tests_core/test_build_thyself.py
@@ -1,4 +1,5 @@
 """Tests of flit_core building itself"""
+import email.parser
 import os
 import os.path as osp
 import pytest
@@ -33,6 +34,12 @@ def test_prepare_metadata(tmp_path, cwd_project):
 
     assert_isfile(osp.join(dist_info, 'WHEEL'))
     assert_isfile(osp.join(dist_info, 'METADATA'))
+
+    # Check METADATA valid in a real package (test_common has minimal examples)
+    with open(osp.join(dist_info, 'METADATA'), 'rb') as f:
+        metadata_b = f.read()
+
+    assert email.parser.BytesParser().parsebytes(metadata_b).defects == []
 
 
 def test_wheel(tmp_path, cwd_project):

--- a/flit_core/tests_core/test_common.py
+++ b/flit_core/tests_core/test_common.py
@@ -150,6 +150,8 @@ def test_metadata_multiline(tmp_path):
         # Example from: https://packaging.python.org/specifications/core-metadata/#author
         'author': ('C. Schultz, Universal Features Syndicate\n'
                    'Los Angeles, CA <cschultz@peanuts.example.com>'),
+        'import_name': 'foo',
+        'description': "Description text\ncan be spread over\n\nmultiple lines",
     }
     md = Metadata(d)
     sio = StringIO()


### PR DESCRIPTION
These would have caught #813 - one in a very specific way, one looking at metadata from `flit_core` itself for a more realistic example.