### PR TITLE
Document optional dependency metadata mapping

### DIFF
--- a/doc/pyproject_toml.rst
+++ b/doc/pyproject_toml.rst
@@ -155,7 +155,8 @@ after a semicolon. For example:
 
 The ``[project.optional-dependencies]`` table contains lists of packages needed
 for every optional feature. The requirements are specified in the same format as
-for ``dependencies``. For example:
+for ``dependencies``. This table is the equivalent of ``requires-extra`` in the
+older ``[tool.flit.metadata]`` format. For example:
 
   .. code-block:: toml
 


### PR DESCRIPTION
## Summary

Document that `[project.optional-dependencies]` is the new-style metadata equivalent of `requires-extra` in `[tool.flit.metadata]`.

Closes #616.

## Validation

- Sphinx documentation build with warnings treated as errors
- `git diff --check`

## AI assistance

Codex (GPT-5) assisted with drafting the documentation wording. I manually reviewed the final diff and verified the documentation build.