### PR TITLE
Allow dotted namespace package names in flit init (#679)

### DIFF
--- a/flit/init.py
+++ b/flit/init.py
@@ -69,6 +69,9 @@ class IniterBase:
     def validate_homepage(self, s):
         return not s or s.startswith(('http://', 'https://'))
 
+    def validate_module_name(self, s):
+        return bool(s) and all(n.isidentifier() for n in s.split('.'))
+
     def guess_module_name(self):
         packages, modules = [], []
         for p in self.directory.iterdir():
@@ -178,7 +181,7 @@ class TerminalIniter(IniterBase):
                 return
 
         module = self.prompt_text('Module name', self.guess_module_name(),
-                                  str.isidentifier)
+                                  self.validate_module_name)
         author = self.prompt_text('Author', self.defaults.get('author'),
                                   lambda s: True)
         author_email = self.prompt_text('Author email',

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -255,3 +255,73 @@ def test_init_non_ascii_author_name():
         with license.open(encoding='utf-8') as f:
             license_text = f.read()
         assert "Test Authôr" in license_text
+
+
+@pytest.mark.parametrize('name', [
+    'my_package',
+    'foo',
+    'my_org.my_pkg',
+    'a.b.c',
+    '_pkg',
+    'pkg_123',
+    'a1.b2.c3',
+])
+def test_validate_module_name_valid(name):
+    ib = init.IniterBase()
+    assert ib.validate_module_name(name) is True
+
+
+@pytest.mark.parametrize('name', [
+    '',
+    '123',
+    'a..b',
+    'a.',
+    '.a',
+    'a-b',
+    'foo bar',
+    'foo/bar',
+    'foo@bar',
+    'foo.123',
+    '123.foo',
+])
+def test_validate_module_name_invalid(name):
+    ib = init.IniterBase()
+    assert ib.validate_module_name(name) is False
+
+
+def test_init_dotted_module_name():
+    responses = ['my_org.my_pkg',  # Module name
+                 'Test Author',      # Author
+                 'test@example.com',  # Author email
+                 '',  # Home page omitted
+                 '4',  # Skip license
+                ]
+    with TemporaryDirectory() as td, \
+          patch_data_dir(), \
+          faking_input(responses):
+        ti = init.TerminalIniter(td)
+        ti.initialise()
+
+        generated = Path(td) / 'pyproject.toml'
+        assert_isfile(generated)
+        with generated.open('rb') as f:
+            data = tomllib.load(f)
+        assert data['project']['name'] == 'my_org.my_pkg'
+
+
+def test_init_module_name_validator():
+    responses = ['invalid-module-name',  # fails validation
+                 'my_org.my_pkg',        # passes validation
+                 'Test Author',
+                 'test@example.com',
+                 '',
+                 '4',
+                ]
+    with TemporaryDirectory() as td, \
+          patch_data_dir(), \
+          faking_input(responses):
+        ti = init.TerminalIniter(td)
+        ti.initialise()
+        with Path(td, 'pyproject.toml').open('rb') as f:
+            data = tomllib.load(f)
+    assert data['project']['name'] == 'my_org.my_pkg'


### PR DESCRIPTION
### Summary

Fixes #679.

`flit init` previously used `str.isidentifier` as the validator for the interactive module name prompt, which rejected valid Python namespace packages containing dot separators (such as `my_org.my_pkg` or `ns.subpkg`).

This change introduces `validate_module_name` in `IniterBase`, ensuring that every dot-separated segment is a valid Python identifier while disallowing empty components or leading/trailing dots.

### Changes
- Added `IniterBase.validate_module_name(s: str) -> bool` validating `bool(s) and all(n.isidentifier() for n in s.split('.'))`.
- Updated `TerminalIniter.initialise()` to use `self.validate_module_name` for module name validation.
- Added comprehensive unit tests in `tests/test_init.py` covering valid/invalid module name patterns and end-to-end `flit init` execution with namespace packages.