### PR TITLE
Enable coverage measurement in subprocesses

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,3 +1,4 @@
 [run]
 omit = */tests/*
     */flit_core/vendor/*
+patch = subprocess


### PR DESCRIPTION
Should fix measuring of some CLI code.
